### PR TITLE
add config-docker target.

### DIFF
--- a/common/Makefile.common.mk
+++ b/common/Makefile.common.mk
@@ -13,6 +13,24 @@
 # limitations under the License.
 
 ############################################################
+# GKE section
+############################################################
+PROJECT ?= oceanic-guard-191815
+ZONE    ?= us-west1-a
+CLUSTER ?= prow
+
+activate-serviceaccount:
+ifdef GOOGLE_APPLICATION_CREDENTIALS
+	gcloud auth activate-service-account --key-file="$(GOOGLE_APPLICATION_CREDENTIALS)"
+endif
+
+get-cluster-credentials: activate-serviceaccount
+	gcloud container clusters get-credentials "$(CLUSTER)" --project="$(PROJECT)" --zone="$(ZONE)"
+
+config-docker: get-cluster-credentials
+	@common/scripts/config_docker.sh
+
+############################################################
 # install git hooks
 ############################################################
 INSTALL_HOOKS := $(shell find .git/hooks -type l -exec rm {} \; && \


### PR DESCRIPTION
Fix:
```
make: *** No rule to make target 'config-docker', needed by 'build-push-images'.  Stop.
```