### PR TITLE
Update bindings structure

### DIFF
--- a/deploy/olm-catalog/ibm-licensing-operator/1.1.0/ibm-licensing-operator.v1.1.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-licensing-operator/1.1.0/ibm-licensing-operator.v1.1.0.clusterserviceversion.yaml
@@ -27,13 +27,12 @@ metadata:
             "operand": "ibm-licensing-operator",
             "registry": "common-service",
             "description": "Binding information that should be accessible to licensing adopters",
-            "bindings": [
-              {
-                "scope": "public",
+            "bindings": {
+              "public": {
                 "secret": "ibm-licensing-token",
                 "configmap": "ibm-licensing-upload-config"
               }
-            ]
+            }
           }
         },
         {


### PR DESCRIPTION
Refactor the operandBindInfo `bindings`
## Background 
The `bindings` in the `OperandBindInfo` and `OperandRequest` is not actually a list, it only includes a `public` scope and a `private ` scope.  Could we use a dual object to replace the list? 
For example,
Change
```
      "spec": {
        "operand": "ibm-licensing-operator",
        "registry": "common-service",
        "description": "Binding information that should be accessible to licensing adopters",
        "bindings": [
          {
            "scope": "public",
            "secret": "ibm-licensing-token"
          }
        ]
      }
```
to
```
      "spec": {
        "operand": "ibm-licensing-operator",
        "registry": "common-service",
        "description": "Binding information that should be accessible to licensing adopters",
        "bindings": {
            "public": {
                 "secret": "ibm-licensing-token",
                 "comfigmap": "ibm-licensing-cm"
              },
            "private": {
                 "secret": "ibm-licensing-token-private",
                 "comfigmap": "ibm-licensing-cm-private"
              }
          }
        ]
      }
```