### PR TITLE
update stable to 1.1.3

### DIFF
--- a/deploy/olm-catalog/ibm-licensing-operator/ibm-licensing-operator.package.yaml
+++ b/deploy/olm-catalog/ibm-licensing-operator/ibm-licensing-operator.package.yaml
@@ -3,7 +3,7 @@ channels:
   name: beta
 - currentCSV: ibm-licensing-operator.v1.1.3
   name: dev
-- currentCSV: ibm-licensing-operator.v1.0.0
+- currentCSV: ibm-licensing-operator.v1.1.3
   name: stable-v1
 defaultChannel: stable-v1
 packageName: ibm-licensing-operator-app


### PR DESCRIPTION
- to merge this PR add comment: `/lgtm`
- after merging clone this repository from master branch
- then in root directory "ibm-licensing-operator" run this command:
```bash
./common/scripts/push-csv.sh
```
- it will prompt for your quay username, then password and then version, for version type: 1.1.3
- after push is done you can verify if after Catalog Source refresh on your cluster stable will point to 1.1.3 (uninstall ibm licensing operator, delete Catalog Source opencloud-operators, wait few minutes, install ibm licensing operator from stable-v1 channel)