### PR TITLE
Fix sender parameters

### DIFF
--- a/deploy/crds/operator.ibm.com_ibmlicensings_crd.yaml
+++ b/deploy/crds/operator.ibm.com_ibmlicensings_crd.yaml
@@ -242,12 +242,12 @@ spec:
                     at Operand level
                   type: string
                 reporterSecretToken:
-                  description: License Reporter authentication token, provided by
-                    secret that you need to create in instance namespace
+                  description: License Service Reporter authentication token, provided
+                    by secret that you need to create in instance namespace
                   type: string
                 reporterURL:
-                  description: URL for License Reporter receiver that collects and
-                    aggregate multi cluster licensing data.
+                  description: URL for License Service Reporter receiver that collects
+                    and aggregate multi cluster licensing data.
                   type: string
               required:
               - clusterID

--- a/deploy/crds/operator.ibm.com_ibmlicensings_crd.yaml
+++ b/deploy/crds/operator.ibm.com_ibmlicensings_crd.yaml
@@ -241,7 +241,7 @@ spec:
                     system. If not provided, CLUSTER_ID will be used as CLUSTER_NAME
                     at Operand level
                   type: string
-                reporterToken:
+                reporterSecretToken:
                   description: License Reporter authentication token, provided by
                     secret that you need to create in instance namespace
                   type: string
@@ -251,7 +251,7 @@ spec:
                   type: string
               required:
               - clusterID
-              - reporterToken
+              - reporterSecretToken
               - reporterURL
               type: object
             version:

--- a/deploy/crds/operator.ibm.com_ibmlicensings_crd.yaml
+++ b/deploy/crds/operator.ibm.com_ibmlicensings_crd.yaml
@@ -241,18 +241,18 @@ spec:
                     system. If not provided, CLUSTER_ID will be used as CLUSTER_NAME
                     at Operand level
                   type: string
-                hubToken:
+                reporterToken:
                   description: License Reporter authentication token, provided by
                     secret that you need to create in instance namespace
                   type: string
-                hubURL:
+                reporterURL:
                   description: URL for License Reporter receiver that collects and
                     aggregate multi cluster licensing data.
                   type: string
               required:
               - clusterID
-              - hubToken
-              - hubURL
+              - reporterToken
+              - reporterURL
               type: object
             version:
               description: Application version

--- a/deploy/crds/operator.ibm.com_ibmlicensings_crd.yaml
+++ b/deploy/crds/operator.ibm.com_ibmlicensings_crd.yaml
@@ -242,7 +242,8 @@ spec:
                     at Operand level
                   type: string
                 hubToken:
-                  description: License Reporter authentication token
+                  description: License Reporter authentication token, provided by
+                    secret that you need to create in instance namespace
                   type: string
                 hubURL:
                   description: URL for License Reporter receiver that collects and

--- a/deploy/olm-catalog/ibm-licensing-operator/1.2.0/operator.ibm.com_ibmlicensings_crd.yaml
+++ b/deploy/olm-catalog/ibm-licensing-operator/1.2.0/operator.ibm.com_ibmlicensings_crd.yaml
@@ -242,12 +242,12 @@ spec:
                     at Operand level
                   type: string
                 reporterSecretToken:
-                  description: License Reporter authentication token, provided by
-                    secret that you need to create in instance namespace
+                  description: License Service Reporter authentication token, provided
+                    by secret that you need to create in instance namespace
                   type: string
                 reporterURL:
-                  description: URL for License Reporter receiver that collects and
-                    aggregate multi cluster licensing data.
+                  description: URL for License Service Reporter receiver that collects
+                    and aggregate multi cluster licensing data.
                   type: string
               required:
               - clusterID

--- a/deploy/olm-catalog/ibm-licensing-operator/1.2.0/operator.ibm.com_ibmlicensings_crd.yaml
+++ b/deploy/olm-catalog/ibm-licensing-operator/1.2.0/operator.ibm.com_ibmlicensings_crd.yaml
@@ -241,7 +241,7 @@ spec:
                     system. If not provided, CLUSTER_ID will be used as CLUSTER_NAME
                     at Operand level
                   type: string
-                reporterToken:
+                reporterSecretToken:
                   description: License Reporter authentication token, provided by
                     secret that you need to create in instance namespace
                   type: string
@@ -251,7 +251,7 @@ spec:
                   type: string
               required:
               - clusterID
-              - reporterToken
+              - reporterSecretToken
               - reporterURL
               type: object
             version:

--- a/deploy/olm-catalog/ibm-licensing-operator/1.2.0/operator.ibm.com_ibmlicensings_crd.yaml
+++ b/deploy/olm-catalog/ibm-licensing-operator/1.2.0/operator.ibm.com_ibmlicensings_crd.yaml
@@ -241,18 +241,18 @@ spec:
                     system. If not provided, CLUSTER_ID will be used as CLUSTER_NAME
                     at Operand level
                   type: string
-                hubToken:
+                reporterToken:
                   description: License Reporter authentication token, provided by
                     secret that you need to create in instance namespace
                   type: string
-                hubURL:
+                reporterURL:
                   description: URL for License Reporter receiver that collects and
                     aggregate multi cluster licensing data.
                   type: string
               required:
               - clusterID
-              - hubToken
-              - hubURL
+              - reporterToken
+              - reporterURL
               type: object
             version:
               description: Application version

--- a/deploy/olm-catalog/ibm-licensing-operator/1.2.0/operator.ibm.com_ibmlicensings_crd.yaml
+++ b/deploy/olm-catalog/ibm-licensing-operator/1.2.0/operator.ibm.com_ibmlicensings_crd.yaml
@@ -242,7 +242,8 @@ spec:
                     at Operand level
                   type: string
                 hubToken:
-                  description: License Reporter authentication token
+                  description: License Reporter authentication token, provided by
+                    secret that you need to create in instance namespace
                   type: string
                 hubURL:
                   description: URL for License Reporter receiver that collects and

--- a/pkg/apis/operator/v1alpha1/ibmlicensing_types.go
+++ b/pkg/apis/operator/v1alpha1/ibmlicensing_types.go
@@ -89,9 +89,9 @@ type IBMLicensingSpec struct {
 }
 
 type IBMLicensingSenderSpec struct {
-	// URL for License Reporter receiver that collects and aggregate multi cluster licensing data.
+	// URL for License Service Reporter receiver that collects and aggregate multi cluster licensing data.
 	ReporterURL string `json:"reporterURL"`
-	// License Reporter authentication token, provided by secret that you need to create in instance namespace
+	// License Service Reporter authentication token, provided by secret that you need to create in instance namespace
 	ReporterSecretToken string `json:"reporterSecretToken"`
 	// What is the name of this reporting cluster in multi-cluster system. If not provided, CLUSTER_ID will be used as CLUSTER_NAME at Operand level
 	ClusterName string `json:"clusterName,omitempty"`

--- a/pkg/apis/operator/v1alpha1/ibmlicensing_types.go
+++ b/pkg/apis/operator/v1alpha1/ibmlicensing_types.go
@@ -91,7 +91,7 @@ type IBMLicensingSpec struct {
 type IBMLicensingSenderSpec struct {
 	// URL for License Reporter receiver that collects and aggregate multi cluster licensing data.
 	HubURL string `json:"hubURL"`
-	// License Reporter authentication token
+	// License Reporter authentication token, provided by secret that you need to create in instance namespace
 	HubToken string `json:"hubToken"`
 	// What is the name of this reporting cluster in multi-cluster system. If not provided, CLUSTER_ID will be used as CLUSTER_NAME at Operand level
 	ClusterName string `json:"clusterName,omitempty"`

--- a/pkg/apis/operator/v1alpha1/ibmlicensing_types.go
+++ b/pkg/apis/operator/v1alpha1/ibmlicensing_types.go
@@ -90,9 +90,9 @@ type IBMLicensingSpec struct {
 
 type IBMLicensingSenderSpec struct {
 	// URL for License Reporter receiver that collects and aggregate multi cluster licensing data.
-	HubURL string `json:"hubURL"`
+	ReporterURL string `json:"reporterURL"`
 	// License Reporter authentication token, provided by secret that you need to create in instance namespace
-	HubToken string `json:"hubToken"`
+	ReporterToken string `json:"reporterToken"`
 	// What is the name of this reporting cluster in multi-cluster system. If not provided, CLUSTER_ID will be used as CLUSTER_NAME at Operand level
 	ClusterName string `json:"clusterName,omitempty"`
 	// Unique ID of reporting cluster

--- a/pkg/apis/operator/v1alpha1/ibmlicensing_types.go
+++ b/pkg/apis/operator/v1alpha1/ibmlicensing_types.go
@@ -92,7 +92,7 @@ type IBMLicensingSenderSpec struct {
 	// URL for License Reporter receiver that collects and aggregate multi cluster licensing data.
 	ReporterURL string `json:"reporterURL"`
 	// License Reporter authentication token, provided by secret that you need to create in instance namespace
-	ReporterToken string `json:"reporterToken"`
+	ReporterSecretToken string `json:"reporterSecretToken"`
 	// What is the name of this reporting cluster in multi-cluster system. If not provided, CLUSTER_ID will be used as CLUSTER_NAME at Operand level
 	ClusterName string `json:"clusterName,omitempty"`
 	// Unique ID of reporting cluster

--- a/pkg/controller/ibmlicensing/ibmlicensing_controller.go
+++ b/pkg/controller/ibmlicensing/ibmlicensing_controller.go
@@ -71,7 +71,7 @@ type ResourceObject interface {
 
 func watchForResources(c controller.Controller, watchTypes []ResourceObject) error {
 	for _, restype := range watchTypes {
-		log.Info("Watching", "restype", restype)
+		log.Info("Watching", "restype", reflect.TypeOf(restype).String())
 		err := c.Watch(&source.Kind{Type: restype}, &handler.EnqueueRequestForOwner{
 			IsController: true,
 			OwnerType:    &operatorv1alpha1.IBMLicensing{},

--- a/pkg/resources/containers.go
+++ b/pkg/resources/containers.go
@@ -85,20 +85,25 @@ func getLicensingEnvironmentVariables(spec operatorv1alpha1.IBMLicensingSpec) []
 				Value: spec.Sender.ClusterID,
 			},
 			{
-				Name:  "HUB_TOKEN",
-				Value: spec.Sender.HubToken,
+				Name: "HUB_TOKEN",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: spec.Sender.HubToken,
+						},
+						Key: HubSecretTokenKeyName,
+					},
+				},
 			},
 			{
 				Name:  "HUB_URL",
 				Value: spec.Sender.HubURL,
 			},
-		}...)
-		if spec.Sender.ClusterName != "" {
-			environmentVariables = append(environmentVariables, corev1.EnvVar{
+			{
 				Name:  "CLUSTER_NAME",
 				Value: spec.Sender.ClusterName,
-			})
-		}
+			},
+		}...)
 	}
 	return environmentVariables
 }

--- a/pkg/resources/containers.go
+++ b/pkg/resources/containers.go
@@ -89,7 +89,7 @@ func getLicensingEnvironmentVariables(spec operatorv1alpha1.IBMLicensingSpec) []
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{
-							Name: spec.Sender.ReporterToken,
+							Name: spec.Sender.ReporterSecretToken,
 						},
 						Key: ReporterSecretTokenKeyName,
 					},

--- a/pkg/resources/containers.go
+++ b/pkg/resources/containers.go
@@ -89,15 +89,15 @@ func getLicensingEnvironmentVariables(spec operatorv1alpha1.IBMLicensingSpec) []
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{
-							Name: spec.Sender.HubToken,
+							Name: spec.Sender.ReporterToken,
 						},
-						Key: HubSecretTokenKeyName,
+						Key: ReporterSecretTokenKeyName,
 					},
 				},
 			},
 			{
 				Name:  "HUB_URL",
-				Value: spec.Sender.HubURL,
+				Value: spec.Sender.ReporterURL,
 			},
 			{
 				Name:  "CLUSTER_NAME",

--- a/pkg/resources/secrets.go
+++ b/pkg/resources/secrets.go
@@ -26,6 +26,8 @@ const APIUploadTokenName = "ibm-licensing-upload-token"
 const APISecretTokenKeyName = "token"
 const APIUploadTokenKeyName = "token-upload"
 
+const HubSecretTokenKeyName = "token"
+
 const UploadConfigMapKey = "url"
 
 func GetAPISecretToken(instance *operatorv1alpha1.IBMLicensing) *corev1.Secret {

--- a/pkg/resources/secrets.go
+++ b/pkg/resources/secrets.go
@@ -26,7 +26,7 @@ const APIUploadTokenName = "ibm-licensing-upload-token"
 const APISecretTokenKeyName = "token"
 const APIUploadTokenKeyName = "token-upload"
 
-const HubSecretTokenKeyName = "token"
+const ReporterSecretTokenKeyName = "token"
 
 const UploadConfigMapKey = "url"
 


### PR DESCRIPTION
- make hub token to be taken from secret instead string
- fix problem with empty cluster name in operand
- fix info log for watcher which did not say what resources are being watched
- change CRD naming of parameters from `hub` to `reporter`