### PR TITLE
Update readme with the newly supported platforms - For License Service Q3 update

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ d. Click **Subscribe**.
 
 5\. **Verify that the installation is successful**
 
-To check whether the installation is successful, wait for about 1 minute, and go to **Installed operators**. You should see IBM Licensing Operator with the **InstallSucceeded** status.
+To check whether the installation is successful, wait for about 1 minute, and go to **Installed operators**. You should see IBM Licensing Operator with the **Succeeded** status.
 
 ![IBM Licensing Installed](images/installed.png)
 
@@ -554,10 +554,10 @@ spec:
 
 After you successfully install IBM Licensing Operator, you need to create IBM Licensing instance to run IBM License Service on a cluster. You can either create an instance in OpenShift or in the console. Choose the option that fits your environment:
 
-- [Creat instance on OpenShift Console 4.2+](#create-instance-on-openshift-console-42)
+- [Create an instance on OpenShift Console 4.2+](#create-an-instance-on-openshift-console-42)
 - [Creating an instance from console](#creating-an-instance-from-console)
 
-#### Create instance on OpenShift Console 4.2+
+#### Create an instance on OpenShift Console 4.2+
 
 If you have OpenShift 4.2+ you can create the instance from the console.
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ For more information about the available IBM Cloud Platform Common Services, see
 
 Red Hat OpenShift Container Platform 4.2 or newer installed on one of the following platforms:
    - Linux x86_64
+   - Linux on Power (ppc64le)
+   - Linux on IBM Z and LinuxONE
 
 ## Operator versions
 
@@ -57,7 +59,12 @@ Use this scenario, only when you do not have IBM Cloud Platform Common Services 
 
 ## Supported platforms for ibm-licensing-operator with stand-alone IBM Containerized Software
 
-License Service is supported on all Kubernetes-orchestrated clouds on Linux x86_64. It was tested on the following systems:
+License Service is supported on all Kubernetes-orchestrated clouds on one of the following platforms:
+   - Linux x86_64
+   - Linux on Power (ppc64le)
+   - Linux on IBM Z and LinuxONE
+
+It was tested on the following systems:
 - Red Hat OpenShift Container Platform 3.11, 4.1, 4.2, 4.3 or newer
 - Kubernetes 1.11.3 or higher
 - IBM Cloud Kubernetes Services (IKS)

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ It was tested on the following systems:
 - Google Kubernetes Engine (GKE)
 - Azure Kubernetes Service (AKS)
 - Amazon EKS - Managed Kubernetes Service (EKS)
+- Alibaba Cloud - Container Service for Kubernetes (ACK)
 
 ## Operator versions for ibm-licensing-operator with stand-alone IBM Containerized Software
 


### PR DESCRIPTION
Changes relating to: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/39265. License Service is from now on also supported on Linux on Power (ppc64le) and Linux on IBM Z and LinuxONE