### PR TITLE
Change rand function for security and fix Reporter CRD potential problem

### DIFF
--- a/deploy/crds/operator.ibm.com_ibmlicenseservicereporters_crd.yaml
+++ b/deploy/crds/operator.ibm.com_ibmlicenseservicereporters_crd.yaml
@@ -35,9 +35,7 @@ spec:
           properties:
             apiSecretToken:
               description: Secret name used to store application token, either one
-                that exists, or one that will be created, for now only one value possible
-              enum:
-              - ibm-licensing-token
+                that exists, or one that will be created
               type: string
             capacity:
               anyOf:

--- a/deploy/crds/operator.ibm.com_ibmlicensings_crd.yaml
+++ b/deploy/crds/operator.ibm.com_ibmlicensings_crd.yaml
@@ -41,9 +41,7 @@ spec:
           properties:
             apiSecretToken:
               description: Secret name used to store application token, either one
-                that exists, or one that will be created, for now only one value possible
-              enum:
-              - ibm-licensing-token
+                that exists, or one that will be created
               type: string
             datasource:
               description: 'Where should data be collected, options: metering, datacollector'
@@ -147,7 +145,7 @@ spec:
               - INFO
               type: string
             resources:
-              description: Resource requirements for License Service container
+              description: Resources and limits for container
               properties:
                 limits:
                   additionalProperties:
@@ -177,7 +175,7 @@ spec:
                 API? (only on OpenShift cluster)
               type: boolean
             routeOptions:
-              description: If route is enabled, you can set its parameters
+              description: Route parameters
               properties:
                 tls:
                   description: TLSConfig defines config used to secure a route and
@@ -255,7 +253,7 @@ spec:
               - reporterURL
               type: object
             version:
-              description: Application version
+              description: Version
               type: string
           required:
           - datasource

--- a/deploy/olm-catalog/ibm-licensing-operator/1.2.0/operator.ibm.com_ibmlicenseservicereporters_crd.yaml
+++ b/deploy/olm-catalog/ibm-licensing-operator/1.2.0/operator.ibm.com_ibmlicenseservicereporters_crd.yaml
@@ -38,13 +38,29 @@ spec:
                 that exists, or one that will be created
               type: string
             capacity:
+              anyOf:
+              - type: integer
+              - type: string
               description: Persistent Volume Claim Capacity
-              type: string
+              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+              x-kubernetes-int-or-string: true
             databaseContainer:
               description: Database Settings
               properties:
-                image:
-                  description: Docker Image
+                imageName:
+                  description: IBM Licensing Service docker Image Name, will override
+                    default value and disable OPERAND_LICENSING_IMAGE env value in
+                    operator deployment
+                  type: string
+                imageRegistry:
+                  description: IBM Licensing Service docker Image Registry, will override
+                    default value and disable OPERAND_LICENSING_IMAGE env value in
+                    operator deployment
+                  type: string
+                imageTagPostfix:
+                  description: IBM Licensing Service docker Image Tag or Digest, will
+                    override default value and disable OPERAND_LICENSING_IMAGE env
+                    value in operator deployment
                   type: string
                 resources:
                   description: Resources and limits for container
@@ -80,8 +96,7 @@ spec:
               - custom
               type: string
             imagePullPolicy:
-              description: 'IBM License Service Reporter Pod pull policy, default:
-                IfNotPresent'
+              description: 'IBM License Service Pod pull policy, default: IfNotPresent'
               enum:
               - Always
               - IfNotPresent
@@ -89,25 +104,34 @@ spec:
               type: string
             imagePullSecrets:
               description: Array of pull secrets which should include existing at
-                InstanceNamespace secret to allow pulling IBM Licensing Reporter images
+                InstanceNamespace secret to allow pulling IBM Licensing image
               items:
                 type: string
               type: array
-            license:
-              description: Opt-in license acceptance is required to create resources
-              properties:
-                accept:
-                  description: Accept is an opt-in license acceptance required to
-                    deploy resources
-                  type: boolean
-              required:
-              - accept
-              type: object
+            logLevel:
+              description: 'Should application pod show additional information, options:
+                DEBUG, INFO'
+              enum:
+              - DEBUG
+              - INFO
+              type: string
             receiverContainer:
               description: Receiver Settings
               properties:
-                image:
-                  description: Docker Image
+                imageName:
+                  description: IBM Licensing Service docker Image Name, will override
+                    default value and disable OPERAND_LICENSING_IMAGE env value in
+                    operator deployment
+                  type: string
+                imageRegistry:
+                  description: IBM Licensing Service docker Image Registry, will override
+                    default value and disable OPERAND_LICENSING_IMAGE env value in
+                    operator deployment
+                  type: string
+                imageTagPostfix:
+                  description: IBM Licensing Service docker Image Tag or Digest, will
+                    override default value and disable OPERAND_LICENSING_IMAGE env
+                    value in operator deployment
                   type: string
                 resources:
                   description: Resources and limits for container
@@ -185,8 +209,6 @@ spec:
             version:
               description: Version
               type: string
-          required:
-          - license
           type: object
         status:
           description: IBMLicenseServiceReporterStatus defines the observed state

--- a/deploy/olm-catalog/ibm-licensing-operator/1.2.0/operator.ibm.com_ibmlicensings_crd.yaml
+++ b/deploy/olm-catalog/ibm-licensing-operator/1.2.0/operator.ibm.com_ibmlicensings_crd.yaml
@@ -41,9 +41,7 @@ spec:
           properties:
             apiSecretToken:
               description: Secret name used to store application token, either one
-                that exists, or one that will be created, for now only one value possible
-              enum:
-              - ibm-licensing-token
+                that exists, or one that will be created
               type: string
             datasource:
               description: 'Where should data be collected, options: metering, datacollector'
@@ -147,7 +145,7 @@ spec:
               - INFO
               type: string
             resources:
-              description: Resource requirements for License Service container
+              description: Resources and limits for container
               properties:
                 limits:
                   additionalProperties:
@@ -177,7 +175,7 @@ spec:
                 API? (only on OpenShift cluster)
               type: boolean
             routeOptions:
-              description: If route is enabled, you can set its parameters
+              description: Route parameters
               properties:
                 tls:
                   description: TLSConfig defines config used to secure a route and
@@ -255,7 +253,7 @@ spec:
               - reporterURL
               type: object
             version:
-              description: Application version
+              description: Version
               type: string
           required:
           - datasource

--- a/pkg/apis/operator/v1alpha1/helper.go
+++ b/pkg/apis/operator/v1alpha1/helper.go
@@ -70,8 +70,7 @@ type IBMLicenseServiceBaseSpec struct {
 	// Should application pod show additional information, options: DEBUG, INFO
 	// +kubebuilder:validation:Enum=DEBUG;INFO
 	LogLevel string `json:"logLevel,omitempty"`
-	// Secret name used to store application token, either one that exists, or one that will be created, for now only one value possible
-	// +kubebuilder:validation:Enum=ibm-licensing-token
+	// Secret name used to store application token, either one that exists, or one that will be created
 	APISecretToken string `json:"apiSecretToken,omitempty"`
 	// Array of pull secrets which should include existing at InstanceNamespace secret to allow pulling IBM Licensing image
 	ImagePullSecrets []string `json:"imagePullSecrets,omitempty"`

--- a/pkg/controller/ibmlicenseservicereporter/ibmlicenseservicereporter_controller.go
+++ b/pkg/controller/ibmlicenseservicereporter/ibmlicenseservicereporter_controller.go
@@ -286,14 +286,30 @@ func (r *ReconcileIBMLicenseServiceReporter) reconcilePersistentVolumeClaim(inst
 }
 
 func (r *ReconcileIBMLicenseServiceReporter) reconcileDatabaseSecret(instance *operatorv1alpha1.IBMLicenseServiceReporter) (reconcile.Result, error) {
-	expectedSecret := reporter.GetDatabaseSecret(instance)
+	reqLogger := log.WithValues("reconcileDatabaseSecret", "Entry", "instance.GetName()", instance.GetName())
+	expectedSecret, err := reporter.GetDatabaseSecret(instance)
+	if err != nil {
+		reqLogger.Info("Failed to get expected secret")
+		return reconcile.Result{
+			Requeue:      true,
+			RequeueAfter: time.Minute,
+		}, err
+	}
 	foundSecret := &corev1.Secret{}
 	namespacedName := types.NamespacedName{Name: expectedSecret.GetName(), Namespace: expectedSecret.GetNamespace()}
 	return r.reconcileResourceExistence(instance, expectedSecret, foundSecret, namespacedName)
 }
 
 func (r *ReconcileIBMLicenseServiceReporter) reconcileAPISecretToken(instance *operatorv1alpha1.IBMLicenseServiceReporter) (reconcile.Result, error) {
-	expectedSecret := reporter.GetAPISecretToken(instance)
+	reqLogger := log.WithValues("reconcileAPISecretToken", "Entry", "instance.GetName()", instance.GetName())
+	expectedSecret, err := reporter.GetAPISecretToken(instance)
+	if err != nil {
+		reqLogger.Info("Failed to get expected secret")
+		return reconcile.Result{
+			Requeue:      true,
+			RequeueAfter: time.Minute,
+		}, err
+	}
 	foundSecret := &corev1.Secret{}
 	namespacedName := types.NamespacedName{Name: expectedSecret.GetName(), Namespace: expectedSecret.GetNamespace()}
 	return r.reconcileResourceExistence(instance, expectedSecret, foundSecret, namespacedName)

--- a/pkg/controller/ibmlicensing/ibmlicensing_controller.go
+++ b/pkg/controller/ibmlicensing/ibmlicensing_controller.go
@@ -302,13 +302,29 @@ func (r *ReconcileIBMLicensing) reconcileNamespace(instance *operatorv1alpha1.IB
 }
 
 func (r *ReconcileIBMLicensing) reconcileAPISecretToken(instance *operatorv1alpha1.IBMLicensing) (reconcile.Result, error) {
-	expectedSecret := service.GetAPISecretToken(instance)
+	reqLogger := log.WithValues("reconcileAPISecretToken", "Entry", "instance.GetName()", instance.GetName())
+	expectedSecret, err := service.GetAPISecretToken(instance)
+	if err != nil {
+		reqLogger.Info("Failed to get expected secret")
+		return reconcile.Result{
+			Requeue:      true,
+			RequeueAfter: time.Minute,
+		}, err
+	}
 	foundSecret := &corev1.Secret{}
 	return r.reconcileResourceNamespacedExistence(instance, expectedSecret, foundSecret)
 }
 
 func (r *ReconcileIBMLicensing) reconcileUploadToken(instance *operatorv1alpha1.IBMLicensing) (reconcile.Result, error) {
-	expectedSecret := service.GetUploadToken(instance)
+	reqLogger := log.WithValues("reconcileUploadToken", "Entry", "instance.GetName()", instance.GetName())
+	expectedSecret, err := service.GetUploadToken(instance)
+	if err != nil {
+		reqLogger.Info("Failed to get expected secret")
+		return reconcile.Result{
+			Requeue:      true,
+			RequeueAfter: time.Minute,
+		}, err
+	}
 	foundSecret := &corev1.Secret{}
 	return r.reconcileResourceNamespacedExistence(instance, expectedSecret, foundSecret)
 }

--- a/pkg/resources/reporter/secrets.go
+++ b/pkg/resources/reporter/secrets.go
@@ -25,22 +25,16 @@ import (
 
 const APIReciverSecretTokenKeyName = "token"
 
-func GetAPISecretToken(instance *operatorv1alpha1.IBMLicenseServiceReporter) *corev1.Secret {
-	metaLabels := LabelsForMeta(instance)
-	expectedSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      instance.Spec.APISecretToken,
-			Namespace: instance.GetNamespace(),
-			Labels:    metaLabels,
-		},
-		Type:       corev1.SecretTypeOpaque,
-		StringData: map[string]string{APIReciverSecretTokenKeyName: res.RandString(24)},
-	}
-	return expectedSecret
+func GetAPISecretToken(instance *operatorv1alpha1.IBMLicenseServiceReporter) (*corev1.Secret, error) {
+	return res.GetSecretToken(instance.Spec.APISecretToken, instance.GetNamespace(), APIReciverSecretTokenKeyName, LabelsForMeta(instance))
 }
 
-func GetDatabaseSecret(instance *operatorv1alpha1.IBMLicenseServiceReporter) *corev1.Secret {
+func GetDatabaseSecret(instance *operatorv1alpha1.IBMLicenseServiceReporter) (*corev1.Secret, error) {
 	metaLabels := LabelsForMeta(instance)
+	randString, err := res.RandString(8)
+	if err != nil {
+		return nil, err
+	}
 	expectedSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      DatabaseConfigSecretName,
@@ -49,11 +43,11 @@ func GetDatabaseSecret(instance *operatorv1alpha1.IBMLicenseServiceReporter) *co
 		},
 		Type: corev1.SecretTypeOpaque,
 		StringData: map[string]string{
-			PostgresPasswordKey:     res.RandString(8),
+			PostgresPasswordKey:     randString,
 			PostgresUserKey:         DatabaseUser,
 			PostgresDatabaseNameKey: DatabaseName,
 			PostgresPgDataKey:       PgData,
 		},
 	}
-	return expectedSecret
+	return expectedSecret, nil
 }

--- a/pkg/resources/service/secrets.go
+++ b/pkg/resources/service/secrets.go
@@ -31,32 +31,12 @@ const ReporterSecretTokenKeyName = "token"
 
 const UploadConfigMapKey = "url"
 
-func GetAPISecretToken(instance *operatorv1alpha1.IBMLicensing) *corev1.Secret {
-	metaLabels := LabelsForMeta(instance)
-	expectedSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      instance.Spec.APISecretToken,
-			Namespace: instance.Spec.InstanceNamespace,
-			Labels:    metaLabels,
-		},
-		Type:       corev1.SecretTypeOpaque,
-		StringData: map[string]string{APISecretTokenKeyName: res.RandString(24)},
-	}
-	return expectedSecret
+func GetAPISecretToken(instance *operatorv1alpha1.IBMLicensing) (*corev1.Secret, error) {
+	return res.GetSecretToken(instance.Spec.APISecretToken, instance.GetNamespace(), APISecretTokenKeyName, LabelsForMeta(instance))
 }
 
-func GetUploadToken(instance *operatorv1alpha1.IBMLicensing) *corev1.Secret {
-	metaLabels := LabelsForMeta(instance)
-	expectedSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      APIUploadTokenName,
-			Namespace: instance.Spec.InstanceNamespace,
-			Labels:    metaLabels,
-		},
-		Type:       corev1.SecretTypeOpaque,
-		StringData: map[string]string{APIUploadTokenKeyName: res.RandString(24)},
-	}
-	return expectedSecret
+func GetUploadToken(instance *operatorv1alpha1.IBMLicensing) (*corev1.Secret, error) {
+	return res.GetSecretToken(APIUploadTokenName, instance.GetNamespace(), APIUploadTokenKeyName, LabelsForMeta(instance))
 }
 
 func GetUploadConfigMap(instance *operatorv1alpha1.IBMLicensing) *corev1.ConfigMap {


### PR DESCRIPTION
- change math rand to crypto rand for security
- fix problem with CRD for LS Reporter having no way to change name of api secret token, now it can be set in CR with any value not only ibm-licensing-token