### PR TITLE
update ui digest with update to 1.2.2

### DIFF
--- a/deploy/olm-catalog/ibm-licensing-operator/1.2.2/ibm-licensing-operator.v1.2.2.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-licensing-operator/1.2.2/ibm-licensing-operator.v1.2.2.clusterserviceversion.yaml
@@ -419,7 +419,7 @@ spec:
                       - name: OPERAND_LICENSING_IMAGE
                         value: quay.io/opencloudio/ibm-licensing@sha256:9a709edfa816072e8abeb80dbd23a58a4853c73a961fa85d49dc84965bba7013
                       - name: OPERAND_REPORTER_UI_IMAGE
-                        value: quay.io/opencloudio/ibm-license-service-reporter-ui@sha256:2b3e67e8f38cf6db579b27653ea0800368f6fd16b134be4d725724ae84558410
+                        value: quay.io/opencloudio/ibm-license-service-reporter-ui@sha256:a70b0a57524f095269f7e13481bc734b33e5393b048b31c67ed63d28d367bf66
                       - name: OPERAND_REPORTER_DATABASE_IMAGE
                         value: quay.io/opencloudio/ibm-postgresql@sha256:397eca770b9526bbedfc1a30cbc1f60f2aefdc3366ae917688bbfa190d861440
                       - name: OPERAND_REPORTER_RECEIVER_IMAGE

--- a/pkg/apis/operator/v1alpha1/helper.go
+++ b/pkg/apis/operator/v1alpha1/helper.go
@@ -40,7 +40,7 @@ const defaultReporterImageName = "ibm-license-service-reporter"
 const defaultReporterImageTagPostfix = "sha256:a1d1bff537c95a781ac8a95bef6f7fdebd24452c95f49eaf61648faba818e747"
 
 const defaultReporterUIImageName = "ibm-license-service-reporter-ui"
-const defaultReporterUIImageTagPostfix = "sha256:2b3e67e8f38cf6db579b27653ea0800368f6fd16b134be4d725724ae84558410"
+const defaultReporterUIImageTagPostfix = "sha256:a70b0a57524f095269f7e13481bc734b33e5393b048b31c67ed63d28d367bf66"
 
 const defaultDatabaseImageName = "ibm-postgresql"
 const defaultDatabaseImageTagPostfix = "sha256:397eca770b9526bbedfc1a30cbc1f60f2aefdc3366ae917688bbfa190d861440"

--- a/pkg/controller/ibmlicenseservicereporter/ibmlicenseservicereporter_controller.go
+++ b/pkg/controller/ibmlicenseservicereporter/ibmlicenseservicereporter_controller.go
@@ -410,7 +410,7 @@ func (r *ReconcileIBMLicenseServiceReporter) reconcileResourceExistence(
 			return reconcile.Result{}, err
 		}
 		// Created successfully - return and requeue
-		return reconcile.Result{Requeue: true, RequeueAfter: time.Minute}, nil
+		return reconcile.Result{Requeue: true, RequeueAfter: time.Second * 5}, nil
 	} else if err != nil {
 		reqLogger.Error(err, "Failed to get "+resType.String(), "Name", expectedRes.GetName(),
 			"Namespace", expectedRes.GetNamespace())


### PR DESCRIPTION
- update ui digest to 1.2.2
- changed delay after resource creation in reporter controller from minute to 5 second as it only happens when resource doesn't exist and has been succesfuly created and with minute added previously it would make client wait too long for all resources to be created