### PR TITLE
Fix log

### DIFF
--- a/common/scripts/tests/tests.bats
+++ b/common/scripts/tests/tests.bats
@@ -119,7 +119,6 @@ EOF
 }
 
 @test "Check if operator log does not contains error" {
-  cat ./operator-sdk_logs.txt | grep "{\"level\":\"error\"" >&3
-  results="$(cat operator-sdk_logs.txt | grep "{\"level\":\"error\"" | wc -l)"
+  results="$(cat ./operator-sdk_logs.txt | grep "{\"level\":\"error\"" | wc -l)"
   [ $results -eq "0" ]
 }

--- a/common/scripts/tests/tests.bats
+++ b/common/scripts/tests/tests.bats
@@ -81,7 +81,7 @@ EOF
 
 @test "Wait for instance to be running" {
   echo "Checking IBMLicensing instance status" >&3
-  retries_start=60
+  retries_start=80
   retries=$retries_start
   retries_wait=3
   until [[ $retries == 0 || $new_ibmlicensing_phase == "Running" || "$ibmlicensing_phase" == "Failed" ]]; do
@@ -105,7 +105,7 @@ EOF
 
 @test "Wait for pods to be deleted" {
   echo "Checking if License Service pod is deleted" >&3
-  retries_start=60
+  retries_start=80
   retries=$retries_start
   retries_wait=3
   results="$(kubectl get pods -n ibm-common-services | grep ibm-licensing-service-instance | wc -l)"
@@ -115,5 +115,11 @@ EOF
     sleep $retries_wait
   done
   echo "Waited $((retries_start*retries_wait-retries*retries_wait)) seconds" >&3
+  [ $results -eq "0" ]
+}
+
+@test "Check if operator log does not contains error" {
+  cat ./operator-sdk_logs.txt | grep "{\"level\":\"error\"" >&3
+  results="$(cat operator-sdk_logs.txt | grep "{\"level\":\"error\"" | wc -l)"
   [ $results -eq "0" ]
 }

--- a/pkg/controller/ibmlicenseservicereporter/ibmlicenseservicereporter_controller.go
+++ b/pkg/controller/ibmlicenseservicereporter/ibmlicenseservicereporter_controller.go
@@ -91,7 +91,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	routeTestInstance := &routev1.Route{}
 	err = mgr.GetClient().Get(context.TODO(), types.NamespacedName{}, routeTestInstance)
 	if err != nil && metaErrors.IsNoMatchError(err) {
-		log.Error(err, "Route CR not found, assuming not on OpenShift Cluster, restart operator if this is wrong")
+		log.Info("Route CR not found, assuming not on OpenShift Cluster, restart operator if this is wrong")
 		isOpenshiftCluster = false
 	}
 

--- a/pkg/controller/ibmlicensing/ibmlicensing_controller.go
+++ b/pkg/controller/ibmlicensing/ibmlicensing_controller.go
@@ -393,7 +393,6 @@ func (r *ReconcileIBMLicensing) reconcileResourceExistence(
 	expectedRes res.ResourceObject,
 	foundRes runtime.Object,
 	namespacedName types.NamespacedName) (reconcile.Result, error) {
-
 	resType := reflect.TypeOf(expectedRes)
 	reqLogger := log.WithValues(resType.String(), "Entry", "instance.GetName()", instance.GetName())
 
@@ -417,7 +416,11 @@ func (r *ReconcileIBMLicensing) reconcileResourceExistence(
 				return reconcile.Result{}, err
 			}
 			// Created successfully - return and requeue
-			return reconcile.Result{Requeue: true, RequeueAfter: time.Second}, nil
+
+			// Pod created successfully - don't requeue
+			return reconcile.Result{}, nil
+
+//			return reconcile.Result{Requeue: true, RequeueAfter: time.Second}, nil
 		}
 		reqLogger.Error(err, "Failed to get "+resType.String(), "Name", expectedRes.GetName(),
 			"Namespace", expectedRes.GetNamespace())

--- a/pkg/controller/ibmlicensing/ibmlicensing_controller.go
+++ b/pkg/controller/ibmlicensing/ibmlicensing_controller.go
@@ -90,7 +90,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	routeTestInstance := &routev1.Route{}
 	err = mgr.GetClient().Get(context.TODO(), types.NamespacedName{}, routeTestInstance)
 	if err != nil && metaErrors.IsNoMatchError(err) {
-		log.Error(err, "Route CR not found, assuming not on OpenShift Cluster, restart operator if this is wrong")
+		log.Info("Route CR not found, assuming not on OpenShift Cluster, restart operator if this is wrong")
 		isOpenshiftCluster = false
 	}
 
@@ -416,11 +416,7 @@ func (r *ReconcileIBMLicensing) reconcileResourceExistence(
 				return reconcile.Result{}, err
 			}
 			// Created successfully - return and requeue
-
-			// Pod created successfully - don't requeue
-			return reconcile.Result{}, nil
-
-//			return reconcile.Result{Requeue: true, RequeueAfter: time.Second}, nil
+			return reconcile.Result{Requeue: true, RequeueAfter: time.Second * 5}, nil
 		}
 		reqLogger.Error(err, "Failed to get "+resType.String(), "Name", expectedRes.GetName(),
 			"Namespace", expectedRes.GetNamespace())


### PR DESCRIPTION
fix for https://github.ibm.com/ibmprivatecloud/roadmap/issues/41189

Most probably this kind of error was because we create e.g. Deployment and we start RequeueAfter 1 second
and after 1 second resource was not created during the next check
which cause trying to create resource again, and this will raise the error " already exists"
I change RequeueAfter to 5s. (like we have it in Reporter Controller)
I also change log from Error log to Info inside a method which discovers if we are in OCP

look at below time:
1600333113.2567666 - creating new resource (in this case deployment)
and start requeue after 1s and reconcile loop start again after 1s in 1600333114.6033208
and in 1600333115.410993 we again go to Deployment we check if it exists (but it is not exists -> it is creating now)
and we try to create again 
and we got error " already exists"

I also change error to info in method which discover if we are on OCP
```
{"level":"info","ts":1600333113.2567666,"logger":"controller_ibmlicensing","msg":"*v1.Deployment does not exist, trying creating new one","*v1.Deployment":"Entry","instance.GetName()":"instance","Name":"ibm-licensing-service-instance","Namespace":"ibm-common-services"}
{"level":"info","ts":1600333114.6033208,"logger":"controller_ibmlicensing","msg":"Reconciling IBMLicensing","Request":"/instance"}
{"level":"info","ts":1600333114.603391,"logger":"controller_ibmlicensing","msg":"got IBM License Service application, version=1.2.2","Request":"/instance"}
{"level":"info","ts":1600333114.6034896,"logger":"controller_ibmlicensing","msg":"*v1.Secret is correct!","*v1.Secret":"Entry","instance.GetName()":"instance"}
{"level":"info","ts":1600333114.60356,"logger":"controller_ibmlicensing","msg":"*v1.Secret is correct!","*v1.Secret":"Entry","instance.GetName()":"instance"}
{"level":"info","ts":1600333114.6035893,"logger":"controller_ibmlicensing","msg":"*v1.ConfigMap is correct!","*v1.ConfigMap":"Entry","instance.GetName()":"instance"}
{"level":"info","ts":1600333114.6036239,"logger":"controller_ibmlicensing","msg":"*v1.Service is correct!","*v1.Service":"Entry","instance.GetName()":"instance"}
{"level":"info","ts":1600333114.6036797,"logger":"controller_ibmlicensing","msg":"*v1.Deployment does not exist, trying creating new one","*v1.Deployment":"Entry","instance.GetName()":"instance","Name":"ibm-licensing-service-instance","Namespace":"ibm-common-services"}
{"level":"error","ts":1600333115.410993,"logger":"controller_ibmlicensing","msg":"Failed to create new *v1.Deployment","*v1.Deployment":"Entry","instance.GetName()":"instance","Name":"ibm-licensing-service-instance","Namespace":"ibm-common-services","error":"deployments.apps \"ibm-licensing-service-instance\" already exists"
```