### PR TITLE
CatalogSource image generation during multiarch task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -477,8 +477,8 @@ scorecard:
 catalogsource: opm
 	curl -Lo ./yq "https://github.com/mikefarah/yq/releases/download/3.4.0/yq_linux_amd64"
 	chmod +x ./yq
-	make bundle-build
 	./yq d -i ./bundle/manifests/ibm-licensing-operator.clusterserviceversion.yaml 'spec.replaces'
+	make bundle-build
 	docker push ${REGISTRY}/${BUNDLE_IMG}
 	$(OPM) index add --permissive -c docker --bundles ${REGISTRY}/${BUNDLE_IMG} --tag ${REGISTRY}/${CATALOG_IMG}
 	docker push  ${REGISTRY}/${CATALOG_IMG}

--- a/Makefile
+++ b/Makefile
@@ -474,18 +474,20 @@ bundle-build-development:
 scorecard:
 	operator-sdk scorecard ./bundle -n ${NAMESPACE} -w 120s
 
-catalogsource: opm bundle-build
+catalogsource: opm
 	curl -Lo ./yq "https://github.com/mikefarah/yq/releases/download/3.4.0/yq_linux_amd64"
 	chmod +x ./yq
+	make bundle-build
 	./yq d -i ./bundle/manifests/ibm-licensing-operator.clusterserviceversion.yaml 'spec.replaces'
 	docker push ${REGISTRY}/${BUNDLE_IMG}
 	$(OPM) index add --permissive -c docker --bundles ${REGISTRY}/${BUNDLE_IMG} --tag ${REGISTRY}/${CATALOG_IMG}
 	docker push  ${REGISTRY}/${CATALOG_IMG}
 
-catalogsource-development: opm bundle-build-development
+catalogsource-development: opm
 	curl -Lo ./yq "https://github.com/mikefarah/yq/releases/download/3.4.0/yq_linux_amd64"
 	chmod +x ./yq
 	./yq d -i ./bundle/manifests/ibm-licensing-operator.clusterserviceversion.yaml 'spec.replaces'
+	make bundle-build-development
 	docker push ${SCRATCH_REGISTRY}/${BUNDLE_IMG}
 	$(OPM) index add --permissive  -c docker  --bundles ${SCRATCH_REGISTRY}/${BUNDLE_IMG} --tag ${SCRATCH_REGISTRY}/${CATALOG_IMG}
 	docker push  ${SCRATCH_REGISTRY}/${CATALOG_IMG}


### PR DESCRIPTION
During creating CatalogSource Image (based on new catalog format bundle format) we got from opm the message:
```replaces nonexistent bundle ibm-licensing-operator.v1.4.1```

```
time="2021-03-25T11:37:42Z" level=info msg="loading bundle file" dir=bundle_tmp021324230/manifests file=operator.ibm.com_ibmlicensings.yaml load=bundle
time="2021-03-25T11:37:42Z" level=warning msg="permissive mode enabled" bundles="[hyc-cloud-private-scratch-docker-local.artifactory.swg-devops.com/ibmcom/ibm-licensing-operator-bundle:1.5.0]" error="Invalid bundle ibm-licensing-operator.v1.5.0, replaces nonexistent bundle ibm-licensing-operator.v1.4.1"
time="2021-03-25T11:37:42Z" level=info msg="Generating dockerfile" bundles="[hyc-cloud-private-scratch-docker-local.artifactory.swg-devops.com/ibmcom/ibm-licensing-operator-bundle:1.5.0]"

```

in such a case, we can or move all CSV to our catalog
or remove replace tag from CSV 
My recommendation option 2
and we need to do that before we made a catalog

This CatalogSource can we used to test task