### PR TITLE
fix for usage container lack of rbac

### DIFF
--- a/bundle/manifests/ibm-license-service_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/ibm-license-service_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -17,3 +17,10 @@ rules:
   verbs:
   - get
   - list
+- apiGroups:
+  - metrics.k8s.io
+  resources:
+  - pods
+  verbs:
+  - get
+  - list

--- a/config/rbac/role_operands.yaml
+++ b/config/rbac/role_operands.yaml
@@ -12,6 +12,14 @@ rules:
     verbs:
       - get
       - list
+  - apiGroups:
+      - "metrics.k8s.io"
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role


### PR DESCRIPTION
probably skip during migration to bundle format
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/46109