### PR TITLE
doc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Red Hat OpenShift Container Platform 4.2 or newer installed on Linux x86_64, Lin
 
 ## Operator versions
 
-- 1.0.0, 1.1.0, 1.1.1, 1.1.2, 1.1.3, 1.2.2, 1.2.3, 1.3.1, 1.4.1
+- 1.0.0, 1.1.0, 1.1.1, 1.1.2, 1.1.3, 1.2.2, 1.2.3, 1.3.1, 1.4.1, 1.5.0
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -4,20 +4,22 @@
 <img alt="Uptime Robot status" src="https://img.shields.io/uptimerobot/status/m786127186-a86f251061d6fd7958c67707?label=OCP%20test%20cluster">
 [![Code Coverage](https://codecov.io/gh/IBM/ibm-licensing-operator/branch/master/graphs/badge.svg?branch=master)](https://codecov.io/gh/IBM/ibm-licensing-operator?branch=master)
 
+**IMPORTANT:** The `master` branch contains the currently developed version of License Service and its content should not be used. Switch to another branch to view the content for the already-released version of License Service, for example `release-<version>` branch.
+
 You can install License Service with ibm-licensing-operator to collect license usage information in two scenarios:
 
-- [License Service as a part of an IBM Cloud Pak (included in IBM Cloud Platform Common Services)](#ibm-licensing-operator)
+- [License Service as a part of an IBM Cloud Pak (included in IBM Cloud Pak foundational services)](#ibm-licensing-operator)
 - [License Service without an IBM Cloud Pak](#ibm-licensing-operator-for-deploying-license-service-without-an-ibm-cloud-pak)
 
 # ibm-licensing-operator
 
-<b>Scenario: License Service as a part of an IBM Cloud Pak (included in IBM Cloud Platform Common Services)</b>
+<b>Scenario: License Service as a part of an IBM Cloud Pak (included in IBM Cloud Pak foundational services)</b>
 
-> **Important:** Do not install this operator directly. Only install this operator using the IBM Common Services Operator. For more information about installing this operator and other Common Services operators, see [Installer documentation](http://ibm.biz/cpcs_opinstall). If you are using this operator as part of an IBM Cloud Pak, see the documentation for that IBM Cloud Pak to learn more about how to install and use the operator service. For more information about IBM Cloud Paks, see [IBM Cloud Paks that use Common Services](http://ibm.biz/cpcs_cloudpaks).
+> **Important:** Do not install this operator directly. Only install this operator using the IBM IBM Cloud Pak foundational services Operator. For more information about installing this operator and other foundational services operators, see [Installer documentation](http://ibm.biz/cpcs_opinstall). If you are using this operator as part of an IBM Cloud Pak, see the documentation for that IBM Cloud Pak to learn more about how to install and use the operator service. For more information about IBM Cloud Paks, see [IBM Cloud Paks that use IBM Cloud Pak foundational services](http://ibm.biz/cpcs_cloudpaks).
 
-You can use the ibm-licensing-operator to install License Service as a part of IBM Cloud Platform Common Services or an IBM Cloud Pak. You can use License Service to collect information about license usage of IBM containerized products and IBM Cloud Paks per cluster. You can retrieve license usage data through a dedicated API call and generate an audit snapshot on demand.
+You can use the `ibm-licensing-operator` to install License Service as a part of IBM Cloud Pak foundational services or an IBM Cloud Pak. You can use License Service to collect information about license usage of IBM containerized products and IBM Cloud Paks per cluster. You can retrieve license usage data through a dedicated API call and generate an audit snapshot on demand.
 
-For more information about the available IBM Cloud Platform Common Services, see the [IBM Knowledge Center](http://ibm.biz/cpcsdocs).
+For more information about the available IBM Cloud Pak foundational services, see the [IBM Documentation](http://ibm.biz/cpcsdocs).
 
 ## Supported platforms
 
@@ -31,17 +33,17 @@ Red Hat OpenShift Container Platform 4.2 or newer installed on Linux x86_64, Lin
 
 Before you install this operator, you need to first install the operator dependencies and prerequisites:
 
-- For the list of operator dependencies, see the IBM Knowledge Center [Common Services dependencies documentation](http://ibm.biz/cpcs_opdependencies).
-- For the list of prerequisites for installing the operator, see the IBM Knowledge Center [Preparing to install services documentation](http://ibm.biz/cpcs_opinstprereq).
+- For the list of operator dependencies, see [Dependencies of the IBM Cloud Pak foundational services](http://ibm.biz/cpcs_opdependencies) in the IBM Documentation.
+- For the list of prerequisites for installing the operator, see [Preparing to install services documentation](http://ibm.biz/cpcs_opinstprereq) in the IBM Documentation.
 
 > **Important:** If you installed License Service with the stand-alone IBM containerized software and you want to install an IBM Cloud Pak, it is recommended to first uninstall License Service from every cluster. Before uninstalling, the best practice is to retrieve an audit snapshot to ensure no data is lost. The Cloud Pak will install a new instance of License Service. This is a temporary action that we would like to automate in the future.
 
 ## Documentation
 
-To install the operator with the IBM Common Services Operator follow the the installation and configuration instructions within the IBM Knowledge Center.
+To install the operator with the IBM Cloud Pak foundational services Operator follow the the installation and configuration instructions within the IBM Documentation.
 
-- If you are using the operator as part of an IBM Cloud Pak, see the documentation for that IBM Cloud Pak. For a list of IBM Cloud Paks, see [IBM Cloud Paks that use Common Services](http://ibm.biz/cpcs_cloudpaks).
-- If you are using the operator with an IBM Containerized Software as a part of IBM Cloud Platform Common Services, see the [Installer documentation](http://ibm.biz/cpcs_opinstall) in Knowledge Center.
+- If you are using the operator as part of an IBM Cloud Pak, see the documentation for that IBM Cloud Pak. For a list of IBM Cloud Paks, see [IBM Cloud Paks that use IBM Cloud Pak foundational services](http://ibm.biz/cpcs_cloudpaks).
+- If you are using the operator with an IBM Containerized Software as a part of IBM Cloud Pak foundational services, see the [Installer documentation](http://ibm.biz/cpcs_opinstall) in IBM Documentation.
 
 ## SecurityContextConstraints Requirements
 
@@ -54,7 +56,7 @@ For more information about the OpenShift Container Platform Security Context Con
 <!--- This documentation is linked under the following short link: https://ibm.biz/license_service4containers. If content is moved update the link through the: Hybrid Cloud ID Team
 --->
 
-<b>Scenario: Learn how to deploy License Service on Kubernetes clusters witout an IBM CLoud Pak</b>
+<b>Scenario: Learn how to deploy License Service on Kubernetes clusters without an IBM CLoud Pak</b>
 
 You can use the `ibm-licensing-operator` to install License Service on any Kubernetes cluster without an IBM CLoud Pak. License Service collects information about license usage of IBM Containerized Products. You can retrieve license usage data through a dedicated API call and generate an audit snapshot on demand.
 

--- a/docs/Content/Install_from_scratch.md
+++ b/docs/Content/Install_from_scratch.md
@@ -184,7 +184,7 @@ a. See if the IBM Licensing Operator is deployed by OLM from the `CatalogSource`
 ```console
 $ kubectl get clusterserviceversion -n ibm-common-services
 NAME                            DISPLAY                  VERSION   REPLACES                        PHASE
-ibm-licensing-operator.v1.4.1   IBM Licensing Operator   1.4.1     ibm-licensing-operator.v1.4.1   Succeeded
+ibm-licensing-operator.v1.5.0   IBM Licensing Operator   1.5.0     ibm-licensing-operator.v1.5.0   Succeeded
 ```
 
 **Note:** The above command assumes that you have created the Subscription in the `ibm-common-services` namespace.

--- a/docs/Content/Install_offline.md
+++ b/docs/Content/Install_offline.md
@@ -20,7 +20,7 @@ This procedure guides you through the installation of License Service. It does n
 1\.Clone the repository by using `git clone`. Run the following command:
 
 ```bash
-export operator_release_version=v1.4.2
+export operator_release_version=v1.5.0
 git clone -b ${operator_release_version} https://github.com/IBM/ibm-licensing-operator.git
 cd ibm-licensing-operator/
 ```

--- a/docs/Content/Install_on_OCP.md
+++ b/docs/Content/Install_on_OCP.md
@@ -94,7 +94,7 @@ Create an IBM Licensing instance.
 
 ![OCP click Create IBM Licensing](/images/ocp_create_instance.png)
 
-2\. Click **Create IBMLicensing** and edit the available parameters if needed.  For more information about the parameters, see the [Custom Resource Definition](/deploy/olm-catalog/ibm-licensing-operator/1.4.1/operator.ibm.com_ibmlicensings_crd.yaml).
+2\. Click **Create IBMLicensing** and edit the available parameters if needed.  For more information about the parameters, see the [Custom Resource Definition](/deploy/olm-catalog/ibm-licensing-operator/1.5.0/operator.ibm.com_ibmlicensings_crd.yaml).
 
 3\. Click **Create**.
 

--- a/docs/Content/Install_without_OLM.md
+++ b/docs/Content/Install_without_OLM.md
@@ -45,7 +45,7 @@ oc project ibm-common-services
 c. Use `git clone`.
 
 ```bash
-export operator_release_version=v1.4.1
+export operator_release_version=v1.5.0
 git clone -b ${operator_release_version} https://github.com/IBM/ibm-licensing-operator.git
 cd ibm-licensing-operator/
 ```

--- a/docs/Content/Preparing_for_installation.md
+++ b/docs/Content/Preparing_for_installation.md
@@ -46,7 +46,7 @@ License Service consists of two main components that require resources: the oper
 
 ### Minimal resource requirements
 
-For minimal resource requirements for License Service, see License Service requirements in [Hardware requirements of small profile](https://www.ibm.com/support/knowledgecenter/SSHKN6/installer/3.x.x/small_profile.html).
+For minimal resource requirements for License Service, see License Service requirements in [Hardware requirements of small profile](https://www.ibm.com/docs/en/cpfs?topic=services-hardware-requirements-small-profile).
 
 <b>Related links</b>
 

--- a/docs/Content/Retrieving_data.md
+++ b/docs/Content/Retrieving_data.md
@@ -15,20 +15,20 @@ You can use a set of dedicated APIs to retrieve the following information:
 - Retrieving information about License Service version
 - Retrieving information about License Service health
 
-To learn how to use the APIs to retrieve data and generate an audit snapshot, see [APIs for retrieving License Service data in IBM Knowledge Center](https://www.ibm.com/support/knowledgecenter/SSHKN6/license-service/1.x.x/retrieving.html).
+To learn how to use the APIs to retrieve data and generate an audit snapshot, see [APIs for retrieving License Service data in IBM Documentation](https://www.ibm.com/docs/en/cpfs?topic=rlud-retrieving-license-usage-data-per-cluster-from-license-service).
 
 ## Tracking license usage in multicluster environment
 
 You can use the data that is collected by License Service from individual clusters to track the cumulative license usage in a multicluster environment. The cumulative report is not required for audit, but it might give you a full overview of your license usage in the multicluster environment.
-For more information, see the overview in [Tracking license usage in multicluster environment](https://www.ibm.com/support/knowledgecenter/SSHKN6/license-service/1.x.x/multicluster.html).
+For more information, see the overview in [Tracking license usage in multicluster environment](https://www.ibm.com/docs/en/cpfs?topic=operator-tracking-license-usage-in-multicluster-environment).
 
-You can use the non-automated procedure to create a cumulative report for your environment. For more information, see [Manually tracking license usage in multicluster environment in IBM Knowledge Center](https://www.ibm.com/support/knowledgecenter/SSHKN6/license-service/1.x.x/multicluster_main.html).
+You can use the non-automated procedure to create a cumulative report for your environment. For more information, see [Manually tracking license usage in multicluster environment in IBM Documentation](https://www.ibm.com/docs/en/cpfs?topic=environment-manually-tracking-license-usage-in-multicluster).
 
 ### License Service Reporter
 
-**Note:** License Service has recently been upgraded with an extension for tracking license usage in multicluster environment called License Service Reporter. However, at this point License Service Reporter is only supported with License Service instance that is shipped with IBM Cloud Platform Common Services and integrated with IBM Cloud Pak solutions.
+**Note:** License Service has recently been upgraded with an extension for tracking license usage in multicluster environment called License Service Reporter. However, at this point License Service Reporter is only supported with License Service instance that is shipped with IBM Cloud Pak foundational services and integrated with IBM Cloud Pak solutions.
 
-If you have an IBM Cloud Pak deployed in your environment and you deployed License Service Reporter, you can configure a non-OpenShift cluster to deliver licensing data to License Service Reporter. For more information, see [Tracking license usage in multicluster environment with License Service Reporter](https://www.ibm.com/support/knowledgecenter/SSHKN6/license-service/1.x.x/license_reporter.html).
+If you have an IBM Cloud Pak deployed in your environment and you deployed License Service Reporter, you can configure a non-OpenShift cluster to deliver licensing data to License Service Reporter. For more information, see [Tracking license usage in multicluster environment with License Service Reporter](https://www.ibm.com/docs/en/cpfs?topic=tluime-tracking-license-usage-in-multicluster-environment-license-service-reporter).
 
 <b>Related links</b>
 - [Go back to home page](../License_Service_main.md#documentation)

--- a/docs/Content/Troubleshooting.md
+++ b/docs/Content/Troubleshooting.md
@@ -7,7 +7,7 @@
 
 ## Verifying completeness of license usage data
 
-You can verify if License Service is properly deployed and whether it collects the complete license usage data. For more information, see [Verifying completeness of license usage data and troubleshooting](https://www.ibm.com/support/knowledgecenter/SSHKN6/license-service/1.x.x/monitoring.html).
+You can verify if License Service is properly deployed and whether it collects the complete license usage data. For more information, see [Verifying completeness of license usage data and troubleshooting](https://www.ibm.com/docs/en/cpfs?topic=operator-verifying-completeness-license-usage-data-troubleshooting).
 
 ## Preparing resources for offline installation without git
 
@@ -15,7 +15,7 @@ You can verify if License Service is properly deployed and whether it collects t
 
 ```bash
 # apply the yaml from here:
-export operator_release_version=v1.4.1
+export operator_release_version=v1.5.0
 kubectl apply -f https://github.com/IBM/ibm-licensing-operator/releases/download/${operator_release_version}/rbac_and_crd.yaml
 ```
 
@@ -52,7 +52,7 @@ spec:
         app.kubernetes.io/managed-by: "ibm-licensing-operator"
         app.kubernetes.io/name: "ibm-licensing"
       annotations:
-        productName: IBM Cloud Platform Common Services
+        productName: IBM Cloud Pak foundational services
         productID: "068a62892a1e4db39641342e592daa25"
         productMetric: FREE
     spec:
@@ -118,7 +118,7 @@ EOF
 
 ## License Service pods are crashing and License Service cannot run
 
-If your License Service pods are crashing and you see multiple instances of License Service with the CrashLoopBackOff status in your OpenShift console, you might have License Service deployed to more than one namespace. As a result, two License Service operators are running in two namespaces and the service crashes. The ibm-licensing-operator should only be deployed in the ibm-common-services namespace, however, if you deployed License Service more than once, the older version of License Service might be deployed to kube-system namespace.
+If your License Service pods are crashing and you see multiple instances of License Service with the `CrashLoopBackOff` status in your OpenShift console, you might have License Service deployed to more than one namespace. As a result, two License Service operators are running in two namespaces and the service crashes. The `ibm-licensing-operator` should only be deployed in the `ibm-common-services` namespace, however, if you deployed License Service more than once, the older version of License Service might be deployed to `kube-system` namespace.
 
 Complete the following steps to fix the problem:
 

--- a/docs/License_Service_main.md
+++ b/docs/License_Service_main.md
@@ -26,7 +26,7 @@ License Service
 
 Currently, supported core-based metrics for container licensing are Processor Value Unit (PVU) and Virtual Processor Core (VPC). For core license metrics, you are obliged to use License Service and periodically generate an audit snapshots to fulfill container licensing requirements.
 
-For more information about core and non-core metrics that are collected by License Service, see [Reported metrics](https://www.ibm.com/support/knowledgecenter/SSHKN6/license-service/1.x.x/reported_metrics.html).
+For more information about core and non-core metrics that are collected by License Service, see [Reported metrics](https://www.ibm.com/docs/en/cpfs?topic=operator-reported-metrics).
 
 License Service collects data that is required for compliance and audit purposes. With License Service, you can retrieve an audit snapshot per cluster without any configuration.
 
@@ -38,7 +38,7 @@ For more information, see the following resources:
 
 - [IBM Container Licenses on Passport Advantage](https://www.ibm.com/software/passportadvantage/containerlicenses.html)
 - [Container licensing FAQs](https://www.ibm.com/software/passportadvantage/containerfaqov.html)
-- [How to: Retrieving an audit snapshot](https://www.ibm.com/support/knowledgecenter/SSHKN6/license-service/1.x.x/APIs.html#auditSnapshot)
+- [How to: Retrieving an audit snapshot](https://www.ibm.com/docs/en/cpfs?topic=service-apis-retrieving-license-data#auditSnapshot)
 
 <b>Best practices</b>
 
@@ -65,7 +65,7 @@ For more information, see the following resources:
     - [Modifying the application deployment resources](Content/Configuration.md#modifying-the-application-deployment-resources)
 - [Retrieving license usage data from the cluster](Content/Retrieving_data.md)
     - [Available APIs](Content/Retrieving_data.md#available-apis)
-    - [Retrieving an audit snapshot](https://www.ibm.com/support/knowledgecenter/SSHKN6/license-service/1.x.x/APIs.html#auditSnapshot)
+    - [Retrieving an audit snapshot](https://www.ibm.com/docs/en/cpfs?topic=service-apis-retrieving-license-data#auditSnapshot)
     - [Tracking license usage in multicluster environment](Content/Retrieving_data.md#tracking-license-usage-in-multicluster-environment)
 - [Uninstalling License Service from a Kubernetes cluster](Content/Uninstalling.md)
 - [Backup and upgrade](Content/Backup_and_upgrade.md)


### PR DESCRIPTION
The following updates are made:
IBM Cloud Platform Common Services -> IBM Cloud Pak foundational services
IBM Knowledge Center -> IBM Documentation
old KC links -> IBM Documentation links

Additionally:
the value of operator_release_version changed to v1.5.0 now
other variables updated to point to 1.5.0
a mote added to readme to call out that master branch contains development content and should not be used