### PR TITLE
Bk doc update 1.10

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,3 +86,12 @@ make
 ```
 
 Now, you can follow the [README](./README.md) to work with the ibm-licensing-operator.
+
+## Version bump
+
+Run script `common/scripts/next_csv.sh` in project root directory with parameters: a current version, new version, old version..
+Example to bump operator from 1.9.0 to 1.10.0:
+
+```shell
+common/scripts/next_csv.sh 1.9.0 1.10.0 1.8.0
+```

--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,9 @@
 #
 
 # Current Operator version
-CSV_VERSION ?= 1.9.0
+CSV_VERSION ?= 1.10.0
 CSV_VERSION_DEVELOPMENT ?= development
-OLD_CSV_VERSION ?= 1.8.0
+OLD_CSV_VERSION ?= 1.9.0
 
 # This repo is build locally for dev/test by default;
 # Override this variable in CI env.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <img alt="Uptime Robot status" src="https://img.shields.io/uptimerobot/status/m786127186-a86f251061d6fd7958c67707?label=OCP%20test%20cluster">
 [![Code Coverage](https://codecov.io/gh/IBM/ibm-licensing-operator/branch/master/graphs/badge.svg?branch=master)](https://codecov.io/gh/IBM/ibm-licensing-operator?branch=master)
 
-**IMPORTANT:** The `master` branch contains the currently developed version of License Service and its content should not be used. Switch to another branch to view the content for the already-released version of License Service, for example `release-<version>` branch.
+**IMPORTANT:** The current branch contains the operator and documentation for License Service version 1.10.x. Switch to another branch to view the content for other releases.
 
 You can install License Service with ibm-licensing-operator to collect license usage information in two scenarios:
 
@@ -27,7 +27,7 @@ Red Hat OpenShift Container Platform 4.2 or newer installed on Linux x86_64, Lin
 
 ## Operator versions
 
-- 1.0.0, 1.1.0, 1.1.1, 1.1.2, 1.1.3, 1.2.2, 1.2.3, 1.3.1, 1.4.1, 1.5.0
+- 1.0.0, 1.1.0, 1.1.1, 1.1.2, 1.1.3, 1.2.2, 1.2.3, 1.3.1, 1.4.1, 1.5.0, 1.6.0, 1.7.0, 1.8.0, 1.9.0, 1.10.0
 
 ## Prerequisites
 

--- a/api/v1alpha1/helper.go
+++ b/api/v1alpha1/helper.go
@@ -109,11 +109,11 @@ func (spec *IBMLicensingSpec) GetDefaultReporterTokenName() string {
 	return defaultReporterTokenSecretName
 }
 
-func (spec *IBMLicensingSpec) IsDebug() bool {
+func (spec *IBMLicenseServiceBaseSpec) IsDebug() bool {
 	return spec.LogLevel == "DEBUG"
 }
 
-func (spec *IBMLicensingSpec) IsVerbose() bool {
+func (spec *IBMLicenseServiceBaseSpec) IsVerbose() bool {
 	return spec.LogLevel == "VERBOSE"
 }
 

--- a/base_images.json
+++ b/base_images.json
@@ -29,7 +29,7 @@
         "destStage": "edge",
         "destNamespace": "build-images",
         "destImage": "ubi7",
-        "tag": "7.9-483",
+        "tag": "7.9-516",
         "updatePackages": []
     },
     {
@@ -40,7 +40,7 @@
         "destStage": "edge",
         "destNamespace": "build-images",
         "destImage": "ubi7-minimal",
-        "tag": "7.9-471",
+        "tag": "7.9-503",
         "updatePackages": []
     },
     {
@@ -55,6 +55,6 @@
         "sourceImage": "ubi8-minimal",
         "sourceTag": "8.4-210",
         "destImage": "node-fermium-ubi8-minimal",
-        "nodeVersion": "14.17.6"
+        "nodeVersion": "14.18.1"
     }
 ]

--- a/bundle/manifests/ibm-licensing-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-licensing-operator.clusterserviceversion.yaml
@@ -15,7 +15,7 @@ metadata:
           "name": "instance"
         },
         "spec": {
-          "version": "1.9.0",
+          "version": "1.10.0",
           "apiSecretToken": "ibm-licensing-token",
           "datasource": "datacollector",
           "httpsEnable": true
@@ -32,7 +32,7 @@ metadata:
           "name": "instance"
         },
         "spec": {
-          "version": "1.9.0"
+          "version": "1.10.0"
         }
       },{
         "apiVersion": "operator.ibm.com/v1alpha1",
@@ -71,10 +71,10 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring
     certified: "false"
-    containerImage: quay.io/opencloudio/ibm-licensing-operator:1.9.0
+    containerImage: quay.io/opencloudio/ibm-licensing-operator:1.10.0
     createdAt: "2020-06-22T10:22:31Z"
     description: The IBM Licensing Operator provides a Kubernetes CRD-Based API to monitor the licensing usage of products.
-    olm.skipRange: '>=1.0.0 <1.9.0'
+    olm.skipRange: '>=1.0.0 <1.10.0'
     operators.operatorframework.io/builder: operator-sdk-v1.11.0
     operators.operatorframework.io/internal-objects: '["ibmlicensingmetadatas.operator.ibm.com"]'
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
@@ -86,7 +86,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: ibm-licensing-operator.v1.9.0
+  name: ibm-licensing-operator.v1.10.0
   namespace: ibm-common-services
 spec:
   apiservicedefinitions: {}
@@ -386,15 +386,15 @@ spec:
                       - ibm-licensing-operator
                     env:
                       - name: IBM_LICENSING_IMAGE
-                        value: quay.io/opencloudio/ibm-licensing:1.9.0
+                        value: quay.io/opencloudio/ibm-licensing:1.10.0
                       - name: IBM_LICENSE_SERVICE_REPORTER_UI_IMAGE
-                        value: quay.io/opencloudio/ibm-license-service-reporter-ui:1.9.0
+                        value: quay.io/opencloudio/ibm-license-service-reporter-ui:1.10.0
                       - name: IBM_POSTGRESQL_IMAGE
-                        value: quay.io/opencloudio/ibm-postgresql:1.9.0
+                        value: quay.io/opencloudio/ibm-postgresql:1.10.0
                       - name: IBM_LICENSE_SERVICE_REPORTER_IMAGE
-                        value: quay.io/opencloudio/ibm-license-service-reporter:1.9.0
+                        value: quay.io/opencloudio/ibm-license-service-reporter:1.10.0
                       - name: IBM_LICENSING_USAGE_IMAGE
-                        value: quay.io/opencloudio/ibm-licensing-usage:1.9.0
+                        value: quay.io/opencloudio/ibm-licensing-usage:1.10.0
                       - name: WATCH_NAMESPACE
                         valueFrom:
                           fieldRef:
@@ -409,7 +409,7 @@ spec:
                         valueFrom:
                           fieldRef:
                             fieldPath: spec.serviceAccountName
-                    image: quay.io/opencloudio/ibm-licensing-operator:1.9.0
+                    image: quay.io/opencloudio/ibm-licensing-operator:1.10.0
                     imagePullPolicy: Always
                     name: ibm-licensing-operator
                     resources:
@@ -628,17 +628,17 @@ spec:
   provider:
     name: IBM
   relatedImages:
-    - image: quay.io/opencloudio/ibm-licensing-operator:1.9.0
+    - image: quay.io/opencloudio/ibm-licensing-operator:1.10.0
       name: IBM_LICENSING_OPERATOR_IMAGE
-    - image: quay.io/opencloudio/ibm-licensing:1.9.0
+    - image: quay.io/opencloudio/ibm-licensing:1.10.0
       name: IBM_LICENSING_IMAGE
-    - image: quay.io/opencloudio/ibm-license-service-reporter-ui:1.9.0
+    - image: quay.io/opencloudio/ibm-license-service-reporter-ui:1.10.0
       name: IBM_LICENSE_SERVICE_REPORTER_UI_IMAGE
-    - image: quay.io/opencloudio/ibm-postgresql:1.9.0
+    - image: quay.io/opencloudio/ibm-postgresql:1.10.0
       name: IBM_POSTGRESQL_IMAGE
-    - image: quay.io/opencloudio/ibm-license-service-reporter:1.9.0
+    - image: quay.io/opencloudio/ibm-license-service-reporter:1.10.0
       name: IBM_LICENSE_SERVICE_REPORTER_IMAGE
-    - image: quay.io/opencloudio/ibm-licensing-usage:1.9.0
+    - image: quay.io/opencloudio/ibm-licensing-usage:1.10.0
       name: IBM_LICENSING_USAGE_IMAGE
-  version: 1.9.0
-  replaces: ibm-licensing-operator.v1.8.0
+  version: 1.10.0
+  replaces: ibm-licensing-operator.v1.9.0

--- a/common/scripts/next_csv.sh
+++ b/common/scripts/next_csv.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2021 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This script needs to inputs
+# The CSV version that is currently in dev
+
+# cs operator
+CURRENT_DEV_CSV=$1
+NEW_DEV_CSV=$2
+PREVIOUS_DEV_CSV=$3
+
+# Update bundle/manifests/ibm-licensing-operator.clusterserviceversion.yaml
+gsed -i "s/$CURRENT_DEV_CSV/$NEW_DEV_CSV/g" bundle/manifests/ibm-licensing-operator.clusterserviceversion.yaml
+gsed -i "s/$PREVIOUS_DEV_CSV/$CURRENT_DEV_CSV/g" bundle/manifests/ibm-licensing-operator.clusterserviceversion.yaml
+echo "Updated the bundle/manifests/ibm-licensing-operator.clusterserviceversion.yaml"
+
+# Update config/manifests/bases/ibm-licensing-operator.clusterserviceversion.yaml
+gsed -i "s/$CURRENT_DEV_CSV/$NEW_DEV_CSV/g" config/manifests/bases/ibm-licensing-operator.clusterserviceversion.yaml
+echo "Updated the config/manifests/bases/ibm-licensing-operator.clusterserviceversion.yaml"
+
+# Update cs operator version only
+gsed -i "s/$CURRENT_DEV_CSV/$NEW_DEV_CSV/g" version/version.go
+echo "Updated the multiarch_image.sh"
+gsed -i "s/$CURRENT_DEV_CSV/$NEW_DEV_CSV/" README.md
+echo "Updated the README.md"
+
+# Update bundle/manifests/ibm-licensing-operator.clusterserviceversion.yaml
+gsed -i "s/$CURRENT_DEV_CSV/$NEW_DEV_CSV/g" Makefile
+gsed -i "s/$PREVIOUS_DEV_CSV/$CURRENT_DEV_CSV/g" Makefile
+echo "Updated the Makefile"
+
+gsed -i "s/$CURRENT_DEV_CSV/$NEW_DEV_CSV/" config/manager/manager.yaml
+echo "Updated the config/manager/manager.yaml"
+
+gsed -i "s/$CURRENT_DEV_CSV/$NEW_DEV_CSV/" bundle/manifests/operator.ibm.com_ibmlicensings.yaml
+gsed -i "s/$CURRENT_DEV_CSV/$NEW_DEV_CSV/" bundle/manifests/operator.ibm.com_ibmlicenseservicereporters.yaml
+echo "Updated the CR examples"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -35,15 +35,15 @@ spec:
             - ibm-licensing-operator
           env:
             - name: IBM_LICENSING_IMAGE
-              value: quay.io/opencloudio/ibm-licensing:1.9.0
+              value: quay.io/opencloudio/ibm-licensing:1.10.0
             - name: IBM_LICENSE_SERVICE_REPORTER_UI_IMAGE
-              value: quay.io/opencloudio/ibm-license-service-reporter-ui:1.9.0
+              value: quay.io/opencloudio/ibm-license-service-reporter-ui:1.10.0
             - name: IBM_POSTGRESQL_IMAGE
-              value: quay.io/opencloudio/ibm-postgresql:1.9.0
+              value: quay.io/opencloudio/ibm-postgresql:1.10.0
             - name: IBM_LICENSE_SERVICE_REPORTER_IMAGE
-              value: quay.io/opencloudio/ibm-license-service-reporter:1.9.0
+              value: quay.io/opencloudio/ibm-license-service-reporter:1.10.0
             - name: IBM_LICENSING_USAGE_IMAGE
-              value: quay.io/opencloudio/ibm-licensing-usage:1.9.0
+              value: quay.io/opencloudio/ibm-licensing-usage:1.10.0
             - name: WATCH_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -58,7 +58,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.serviceAccountName
-          image: quay.io/opencloudio/ibm-licensing-operator:1.9.0
+          image: quay.io/opencloudio/ibm-licensing-operator:1.10.0
           imagePullPolicy: Always
           name: ibm-licensing-operator
           resources:

--- a/config/manifests/bases/ibm-licensing-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-licensing-operator.clusterserviceversion.yaml
@@ -6,11 +6,11 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring
     certified: "false"
-    containerImage: quay.io/opencloudio/ibm-licensing-operator:1.9.0
+    containerImage: quay.io/opencloudio/ibm-licensing-operator:1.10.0
     createdAt: "2020-06-22T10:22:31Z"
     description: The IBM Licensing Operator provides a Kubernetes CRD-Based API to
       monitor the licensing usage of products.
-    olm.skipRange: '>=1.0.0 <1.9.0'
+    olm.skipRange: '>=1.0.0 <1.10.0'
     operators.operatorframework.io/builder: operator-sdk-v1.2.0
     operators.operatorframework.io/internal-objects: '["ibmlicensingmetadatas.operator.ibm.com"]'
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
@@ -306,16 +306,16 @@ spec:
   provider:
     name: IBM
   relatedImages:
-  - image: quay.io/opencloudio/ibm-licensing-operator:1.9.0
+  - image: quay.io/opencloudio/ibm-licensing-operator:1.10.0
     name: IBM_LICENSING_OPERATOR_IMAGE
-  - image: quay.io/opencloudio/ibm-licensing:1.9.0
+  - image: quay.io/opencloudio/ibm-licensing:1.10.0
     name: IBM_LICENSING_IMAGE
-  - image: quay.io/opencloudio/ibm-license-service-reporter-ui:1.9.0
+  - image: quay.io/opencloudio/ibm-license-service-reporter-ui:1.10.0
     name: IBM_LICENSE_SERVICE_REPORTER_UI_IMAGE
-  - image: quay.io/opencloudio/ibm-postgresql:1.9.0
+  - image: quay.io/opencloudio/ibm-postgresql:1.10.0
     name: IBM_POSTGRESQL_IMAGE
-  - image: quay.io/opencloudio/ibm-license-service-reporter:1.9.0
+  - image: quay.io/opencloudio/ibm-license-service-reporter:1.10.0
     name: IBM_LICENSE_SERVICE_REPORTER_IMAGE
-  - image: quay.io/opencloudio/ibm-licensing-usage:1.9.0
+  - image: quay.io/opencloudio/ibm-licensing-usage:1.10.0
     name: IBM_LICENSING_USAGE_IMAGE
   version: 0.0.0

--- a/controllers/ibmlicensing_controller.go
+++ b/controllers/ibmlicensing_controller.go
@@ -199,7 +199,7 @@ func (r *IBMLicensingReconciler) updateStatus(instance *operatorv1alpha1.IBMLice
 		instance.Status.LicensingPods = podStatuses
 		err := r.Client.Status().Update(context.TODO(), instance)
 		if err != nil {
-			reqLogger.Info("Warning: Failed to update pod status, this does not affect License Service")
+			reqLogger.Info("Failed to update pod status, this does not affect License Service")
 		}
 	}
 

--- a/controllers/resources/helper.go
+++ b/controllers/resources/helper.go
@@ -102,6 +102,29 @@ func Contains(s []corev1.LocalObjectReference, e corev1.LocalObjectReference) bo
 	return false
 }
 
+// we could use reflection to have this method for all types but for now strings would be enough
+func ListsEqualsLikeSets(list1 []string, list2 []string) bool {
+	if list1 == nil {
+		return list2 == nil
+	}
+	if len(list1) != len(list2) {
+		return false
+	}
+	for _, item1 := range list1 {
+		found := false
+		for _, item2 := range list2 {
+			if item2 == item1 {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
 func AnnotationsForPod() map[string]string {
 	return map[string]string{"productName": LicensingProductName,
 		"productID": LicensingProductID, "productMetric": LicensingProductMetric}

--- a/controllers/resources/reporter/helper.go
+++ b/controllers/resources/reporter/helper.go
@@ -104,6 +104,18 @@ func getReciverEnvVariables(spec operatorv1alpha1.IBMLicenseServiceReporterSpec)
 			Value: string(spec.HTTPSCertsSource),
 		},
 	}
+	if spec.IsDebug() {
+		environmentVariables = append(environmentVariables, corev1.EnvVar{
+			Name:  "logging.level.com.ibm",
+			Value: "DEBUG",
+		})
+	}
+	if spec.IsDebug() || spec.IsVerbose() {
+		environmentVariables = append(environmentVariables, corev1.EnvVar{
+			Name:  "SPRING_PROFILES_ACTIVE",
+			Value: "verbose",
+		})
+	}
 	if spec.EnvVariable != nil {
 		for key, value := range spec.EnvVariable {
 			environmentVariables = append(environmentVariables, corev1.EnvVar{

--- a/controllers/resources/service/meter_definition.go
+++ b/controllers/resources/service/meter_definition.go
@@ -25,7 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func GetMeterDefinition(instance *operatorv1alpha1.IBMLicensing) []*rhmp.MeterDefinition {
+func GetMeterDefinitionList(instance *operatorv1alpha1.IBMLicensing) []*rhmp.MeterDefinition {
 	return []*rhmp.MeterDefinition{
 		getCloudPakMeterDefinition(instance),
 		getProductMeterDefinition(instance),
@@ -102,9 +102,9 @@ func getProductMeterDefinition(instance *operatorv1alpha1.IBMLicensing) *rhmp.Me
 					Aggregation:        "max",
 					Period:             &metav1.Duration{Duration: 24 * time.Hour},
 					WorkloadType:       rhmp.WorkloadTypeService,
-					Metric:             "{{ .Label.metricId}}",
+					Metric:             "{{ .Label.parentMetricId}}",
 					Query:              "avg_over_time(product_license_usage_details{}[1d])",
-					GroupBy:            []string{"metricId", "productId"},
+					GroupBy:            []string{"metricId", "productId", "parentMetricId", "parentProductId", "productConversionRatio"},
 					ValueLabelOverride: "{{ .Label.value}}",
 					DateLabelOverride:  "{{ .Label.date}}",
 				},
@@ -142,9 +142,9 @@ func getChargebackMeterDefinition(instance *operatorv1alpha1.IBMLicensing) *rhmp
 					Aggregation:        "max",
 					Period:             &metav1.Duration{Duration: 24 * time.Hour},
 					WorkloadType:       rhmp.WorkloadTypeService,
-					Metric:             "{{ .Label.metricId}}",
+					Metric:             "{{ .Label.parentMetricId}}",
 					Query:              "avg_over_time(product_license_usage_chargeback{}[1d])",
-					GroupBy:            []string{"metricId", "productId"},
+					GroupBy:            []string{"metricId", "productId", "parentMetricId", "parentProductId", "productConversionRatio"},
 					ValueLabelOverride: "{{ .Label.value}}",
 					DateLabelOverride:  "{{ .Label.date}}",
 				},

--- a/docs/Content/Install_from_scratch.md
+++ b/docs/Content/Install_from_scratch.md
@@ -199,7 +199,7 @@ a. See if the IBM Licensing Operator is deployed by OLM from the `CatalogSource`
 ```console
 $ kubectl get clusterserviceversion -n ibm-common-services
 NAME                            DISPLAY                  VERSION   REPLACES                        PHASE
-ibm-licensing-operator.v1.5.0   IBM Licensing Operator   1.5.0     ibm-licensing-operator.v1.5.0   Succeeded
+ibm-licensing-operator.v1.10.0   IBM Licensing Operator   1.10.0     ibm-licensing-operator.v1.10.0   Succeeded
 ```
 
 **Note:** The above command assumes that you have created the Subscription in the `ibm-common-services` namespace.

--- a/docs/Content/Install_offline.md
+++ b/docs/Content/Install_offline.md
@@ -121,6 +121,7 @@ fi
 # add CRD:
 kubectl apply -f config/crd/bases/operator.ibm.com_ibmlicensings.yaml
 kubectl apply -f config/crd/bases/operator.ibm.com_ibmlicenseservicereporters.yaml
+kubectl apply -f config/crd/bases/operator.ibm.com_ibmlicensingmetadatas.yaml
 # add RBAC:
 kubectl apply -f config/rbac/role.yaml
 kubectl apply -f config/rbac/role_operands.yaml
@@ -142,6 +143,7 @@ fi
 # add CRD:
 kubectl apply -f config/crd/bases/operator.ibm.com_ibmlicensings.yaml
 kubectl apply -f config/crd/bases/operator.ibm.com_ibmlicenseservicereporters.yaml
+kubectl apply -f config/crd/bases/operator.ibm.com_ibmlicensingmetadatas.yaml
 # add RBAC:
 kubectl apply -f config/rbac/role.yaml
 kubectl apply -f config/rbac/role_operands.yaml

--- a/docs/Content/Install_offline.md
+++ b/docs/Content/Install_offline.md
@@ -20,12 +20,12 @@ This procedure guides you through the installation of License Service. It does n
 1\. Clone the repository by using `git clone`. Run the following command:
 
 ```bash
-export operator_release_version=v1.8.0
+export operator_release_version=v1.10.0
 git clone -b ${operator_release_version} https://github.com/IBM/ibm-licensing-operator.git
 cd ibm-licensing-operator/
 ```
 
-**Note:** If you cannot use `git clone`, just download the sources, unzip, and enter ibm-licensing-operator directory. [Sources](https://github.com/IBM/ibm-licensing-operator/archive/refs/heads/release-1.8.zip)
+**Note:** If you cannot use `git clone`, just download the sources, unzip, and enter ibm-licensing-operator directory. [Sources](https://github.com/IBM/ibm-licensing-operator/archive/refs/heads/release-1.10.zip)
 
 2\. Prepare Docker images.
 

--- a/docs/Content/Install_without_OLM.md
+++ b/docs/Content/Install_without_OLM.md
@@ -45,7 +45,7 @@ oc project ${licensing_namespace}
 3\. Use `git clone`.
 
 ```bash
-export operator_release_version=v1.8.0
+export operator_release_version=v1.10.0
 git clone -b ${operator_release_version} https://github.com/IBM/ibm-licensing-operator.git
 cd ibm-licensing-operator/
 ```

--- a/docs/Content/Install_without_OLM.md
+++ b/docs/Content/Install_without_OLM.md
@@ -20,16 +20,16 @@ Complete the following procedure to install License Service on a system that doe
 
 This procedure guides you through the installation of License Service. It does not cover the installation of License Service Reporter which is not available without an IBM Cloud Pak on OpenShift Container Platform.
 
-1\. Create the required resources.
+Complete the following steps to create the required resources.
 
-a. Run the following command to create the `ibm-common-services` namespace where you will later install the operator.
+1\. Run the following command to create the `ibm-common-services` namespace where you will later install the operator.
 
 ```bash
 export licensing_namespace=ibm-common-services
 kubectl create namespace ${licensing_namespace}
 ```
 
-b. Use the following command to set the context so that the resources are created.
+2\. Use the following command to set the context so that the resources are created.
 
 ```bash
 current_context=$(kubectl config current-context)
@@ -42,7 +42,7 @@ or when you are using OpenShift just:
 oc project ${licensing_namespace}
 ```
 
-c. Use `git clone`.
+3\. Use `git clone`.
 
 ```bash
 export operator_release_version=v1.8.0
@@ -50,7 +50,7 @@ git clone -b ${operator_release_version} https://github.com/IBM/ibm-licensing-op
 cd ibm-licensing-operator/
 ```
 
-d. Switch namespaces in rbac if different namespace than `ibm-common-services`:
+4\. Switch namespaces in rbac if different namespace than `ibm-common-services`:
 
 - For **LINUX** users:
 
@@ -68,12 +68,13 @@ if [ "${licensing_namespace}" != "" ] && [ "${licensing_namespace}" != "ibm-comm
 fi
 ```
 
-e. Apply RBAC roles and CRD:
+5\. Apply RBAC roles and CRD:
 
 ```bash
 # add CRD:
 kubectl apply -f config/crd/bases/operator.ibm.com_ibmlicensings.yaml
 kubectl apply -f config/crd/bases/operator.ibm.com_ibmlicenseservicereporters.yaml
+kubectl apply -f config/crd/bases/operator.ibm.com_ibmlicensingmetadatas.yaml
 # add RBAC:
 kubectl apply -f config/rbac/role.yaml
 kubectl apply -f config/rbac/role_operands.yaml
@@ -81,7 +82,7 @@ kubectl apply -f config/rbac/service_account.yaml
 kubectl apply -f config/rbac/role_binding.yaml
 ```
 
-f. Modify the `operator.yaml` image based on tags.
+6\. Modify the `operator.yaml` image based on tags.
 
 - For **LINUX** users:
 
@@ -105,7 +106,7 @@ Create an IBM Licensing instance.
 
 ## Creating an IBM Licensing instance
 
-1\. To create the IBM Licensing instance, run the following command.
+ To create the IBM Licensing instance, run the following command.
 
 ```yaml
 cat <<EOF | kubectl apply -f -

--- a/docs/Content/Installation_scenarios.md
+++ b/docs/Content/Installation_scenarios.md
@@ -7,7 +7,7 @@ Install License Service and create the operator instance.
 Choose the installation path that fits your environment best.
 
 - [Automatic installation using Operator Lifecycle Manager (OLM)](Automatic_installation.md)
-- [Manual installation on OpenShift Container Platform (OCP) version 4.2 or higher](Install_on_OCP.md)
+- [Manual installation on OpenShift Container Platform (OCP) version 4.6 or higher](Install_on_OCP.md)
 - [Manual installation without the Operator Lifecycle Manager (OLM)](Install_without_OLM.md)
 - [Manual installation on Kubernetes from scratch with `kubectl`](Install_from_scratch.md)
 - [Offline installation](Install_offline.md)

--- a/docs/Content/Preparing_for_installation.md
+++ b/docs/Content/Preparing_for_installation.md
@@ -48,6 +48,12 @@ License Service consists of two main components that require resources: the oper
 
 For minimal resource requirements for License Service, see License Service requirements in [Hardware requirements of small profile](https://www.ibm.com/docs/en/cpfs?topic=services-hardware-requirements-small-profile).
 
+## Hyperthreading
+
+License Service supports multiple threads per physical core also referred to as Simultaneous multithreading (SMT) or Hyper-Threading (HT).
+
+For more information about how to enable hyperthreading in License Service, and examples, see [Hyperthreading](https://www.ibm.com/docs/en/cpfs?topic=operator-hyperthreading).
+
 <b>Related links</b>
 
 - [Go back to home page](../License_Service_main.md#documentation)

--- a/docs/Content/Uninstalling.md
+++ b/docs/Content/Uninstalling.md
@@ -18,17 +18,20 @@ Complete the following steps to uninstall License Service in online and offline 
 
 ## Step 1: Deleting the IBM Licensing resource
 
-1\. Delete the `IBMLicensing custom` resource.
+Delete the `IBMLicensing custom` resource.
 
 Delete the instance and the operator will clean its resources.
-First, check what `ibmlicensing` instances you have by running the following command:
+
+1\. Check what `ibmlicensing` instances you have by running the following command:
 
 ```bash
 licensingNamespace=ibm-common-services
 kubectl get ibmlicensing -n ${licensingNamespace} -o jsonpath="{range .items[*]}{.metadata.name}{'\n'}"
 ```
 
-The command should return one instance. Delete this instance, if it exists with the following command:
+The command should return one instance. 
+
+2\. Delete this instance, if it exists with the following command:
 
 ```bash
 licensingNamespace=ibm-common-services

--- a/docs/License_Service_main.md
+++ b/docs/License_Service_main.md
@@ -18,9 +18,10 @@ License Service collects and measures the license usage of your products at the 
 License Service
 
 - Collects and measures the license usage of Virtual Processor Core (VPC) and Processor Value Unit (PVU) metrics at the cluster level of IBM Containerized products that are enabled for reporting. To learn if your product is enabled for reporting, contact the product support.
-- Currently, License Service refreshes the data every 5 minutes. However, this might be subject to change in the future. With this frequency, you can capture changes in a dynamic cloud environment.
+- Currently, License Service refreshes the data every 5 minutes. With this frequency, you can capture changes in a dynamic cloud environment. License Service stores the historical licensing data for the last 24 months. However, the frequency and the retention period might be subject to change in the future.
 - Provides the API that you can use to retrieve data that outlines the highest license usage on the cluster.
 - Provides the API that you can use to retrieve an audit snapshot that lists the highest license usage values for the requested period for products that are deployed on a cluster.
+- Supports hyperthreading on worker nodes also referred to as Simultaneous multithreading (SMT) or Hyperthreading (HT).
 
 ## Using License Service for container licensing
 
@@ -51,6 +52,7 @@ For more information, see the following resources:
 - [Preparing for installation](Content/Preparing_for_installation.md)
     - [Supported platforms](Content/Preparing_for_installation.md#supported-platforms)
     - [Required resources](Content/Preparing_for_installation.md#required-resources)
+    - [Hyperthreading](Content/Preparing_for_installation.md#hyperthreading)
 - [Installing License Service](Content/Installation_scenarios.md)
     - [Automatically installing ibm-licensing-operator with a stand-alone IBM Containerized Software using Operator Lifecycle Manager (OLM)](Content/Automatic_installation.md)
     - [Manually installing License Service on OCP 4.2+](Content/Install_on_OCP.md)

--- a/version/version.go
+++ b/version/version.go
@@ -16,5 +16,5 @@
 package version
 
 var (
-	Version = "1.9.0"
+	Version = "1.10.0"
 )


### PR DESCRIPTION
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/50573

@SzymonKowalczyk 

Versions changes to 1.10 and hyperthreading added. 

Questions: 
1. Do we need to list all operator versions in readme.md? Are all these versions supported?
2. I put hyperthreading in preparing to install topic. Is that a good fit? Or would it be better under configuration? 