### PR TITLE
update documentation for 1.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <img alt="Uptime Robot status" src="https://img.shields.io/uptimerobot/status/m786127186-a86f251061d6fd7958c67707?label=OCP%20test%20cluster">
 [![Code Coverage](https://codecov.io/gh/IBM/ibm-licensing-operator/branch/master/graphs/badge.svg?branch=master)](https://codecov.io/gh/IBM/ibm-licensing-operator?branch=master)
 
-**IMPORTANT:** The `master` branch contains the currently developed version of License Service and its content should not be used. Switch to another branch to view the content for the already-released version of License Service, for example `release-<version>` branch.
+**IMPORTANT:** The current branch contains the operator and documentation for License Service version 1.10.x. Switch to another branch to view the content for other releases.
 
 You can install License Service with ibm-licensing-operator to collect license usage information in two scenarios:
 
@@ -27,7 +27,7 @@ Red Hat OpenShift Container Platform 4.2 or newer installed on Linux x86_64, Lin
 
 ## Operator versions
 
-- 1.0.0, 1.1.0, 1.1.1, 1.1.2, 1.1.3, 1.2.2, 1.2.3, 1.3.1, 1.4.1, 1.5.0
+- 1.0.0, 1.1.0, 1.1.1, 1.1.2, 1.1.3, 1.2.2, 1.2.3, 1.3.1, 1.4.1, 1.5.0, 1.6.0, 1.7.0, 1.8.0, 1.9.0, 1.10.0
 
 ## Prerequisites
 

--- a/docs/Content/Install_from_scratch.md
+++ b/docs/Content/Install_from_scratch.md
@@ -199,7 +199,7 @@ a. See if the IBM Licensing Operator is deployed by OLM from the `CatalogSource`
 ```console
 $ kubectl get clusterserviceversion -n ibm-common-services
 NAME                            DISPLAY                  VERSION   REPLACES                        PHASE
-ibm-licensing-operator.v1.5.0   IBM Licensing Operator   1.5.0     ibm-licensing-operator.v1.5.0   Succeeded
+ibm-licensing-operator.v1.10.0   IBM Licensing Operator   1.10.0     ibm-licensing-operator.v1.10.0   Succeeded
 ```
 
 **Note:** The above command assumes that you have created the Subscription in the `ibm-common-services` namespace.

--- a/docs/Content/Install_offline.md
+++ b/docs/Content/Install_offline.md
@@ -20,12 +20,12 @@ This procedure guides you through the installation of License Service. It does n
 1\. Clone the repository by using `git clone`. Run the following command:
 
 ```bash
-export operator_release_version=v1.8.0
+export operator_release_version=v1.10.0
 git clone -b ${operator_release_version} https://github.com/IBM/ibm-licensing-operator.git
 cd ibm-licensing-operator/
 ```
 
-**Note:** If you cannot use `git clone`, just download the sources, unzip, and enter ibm-licensing-operator directory. [Sources](https://github.com/IBM/ibm-licensing-operator/archive/refs/heads/release-1.8.zip)
+**Note:** If you cannot use `git clone`, just download the sources, unzip, and enter ibm-licensing-operator directory. [Sources](https://github.com/IBM/ibm-licensing-operator/archive/refs/heads/release-1.10.zip)
 
 2\. Prepare Docker images.
 

--- a/docs/Content/Install_without_OLM.md
+++ b/docs/Content/Install_without_OLM.md
@@ -45,7 +45,7 @@ oc project ${licensing_namespace}
 3\. Use `git clone`.
 
 ```bash
-export operator_release_version=v1.8.0
+export operator_release_version=v1.10.0
 git clone -b ${operator_release_version} https://github.com/IBM/ibm-licensing-operator.git
 cd ibm-licensing-operator/
 ```

--- a/docs/Content/Installation_scenarios.md
+++ b/docs/Content/Installation_scenarios.md
@@ -7,7 +7,7 @@ Install License Service and create the operator instance.
 Choose the installation path that fits your environment best.
 
 - [Automatic installation using Operator Lifecycle Manager (OLM)](Automatic_installation.md)
-- [Manual installation on OpenShift Container Platform (OCP) version 4.2 or higher](Install_on_OCP.md)
+- [Manual installation on OpenShift Container Platform (OCP) version 4.6 or higher](Install_on_OCP.md)
 - [Manual installation without the Operator Lifecycle Manager (OLM)](Install_without_OLM.md)
 - [Manual installation on Kubernetes from scratch with `kubectl`](Install_from_scratch.md)
 - [Offline installation](Install_offline.md)

--- a/docs/Content/Preparing_for_installation.md
+++ b/docs/Content/Preparing_for_installation.md
@@ -48,6 +48,12 @@ License Service consists of two main components that require resources: the oper
 
 For minimal resource requirements for License Service, see License Service requirements in [Hardware requirements of small profile](https://www.ibm.com/docs/en/cpfs?topic=services-hardware-requirements-small-profile).
 
+## Hyperthreading
+
+License Service supports multiple threads per physical core also referred to as Simultaneous multithreading (SMT) or Hyper-Threading (HT).
+
+For more information about how to enable hyperthreading in License Service, and examples, see [Hyperthreading](https://www.ibm.com/docs/en/cpfs?topic=operator-hyperthreading).
+
 <b>Related links</b>
 
 - [Go back to home page](../License_Service_main.md#documentation)

--- a/docs/License_Service_main.md
+++ b/docs/License_Service_main.md
@@ -18,9 +18,10 @@ License Service collects and measures the license usage of your products at the 
 License Service
 
 - Collects and measures the license usage of Virtual Processor Core (VPC) and Processor Value Unit (PVU) metrics at the cluster level of IBM Containerized products that are enabled for reporting. To learn if your product is enabled for reporting, contact the product support.
-- Currently, License Service refreshes the data every 5 minutes. However, this might be subject to change in the future. With this frequency, you can capture changes in a dynamic cloud environment.
+- Currently, License Service refreshes the data every 5 minutes. With this frequency, you can capture changes in a dynamic cloud environment. License Service stores the historical licensing data for the last 24 months. However, the frequency and the retention period might be subject to change in the future.
 - Provides the API that you can use to retrieve data that outlines the highest license usage on the cluster.
 - Provides the API that you can use to retrieve an audit snapshot that lists the highest license usage values for the requested period for products that are deployed on a cluster.
+- Supports hyperthreading on worker nodes also referred to as Simultaneous multithreading (SMT) or Hyperthreading (HT).
 
 ## Using License Service for container licensing
 
@@ -51,6 +52,7 @@ For more information, see the following resources:
 - [Preparing for installation](Content/Preparing_for_installation.md)
     - [Supported platforms](Content/Preparing_for_installation.md#supported-platforms)
     - [Required resources](Content/Preparing_for_installation.md#required-resources)
+    - [Hyperthreading](Content/Preparing_for_installation.md#hyperthreading)
 - [Installing License Service](Content/Installation_scenarios.md)
     - [Automatically installing ibm-licensing-operator with a stand-alone IBM Containerized Software using Operator Lifecycle Manager (OLM)](Content/Automatic_installation.md)
     - [Manually installing License Service on OCP 4.2+](Content/Install_on_OCP.md)


### PR DESCRIPTION
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/50573

@SzymonKowalczyk

Versions changes to 1.10 and hyperthreading added.

Questions:

    Do we need to list all operator versions in readme.md? Are all these versions supported?
    I put hyperthreading in preparing to install topic. Is that a good fit? Or would it be better under configuration?
