### PR TITLE
Fips compliance lsr (#696)

### DIFF
--- a/controllers/ibmlicenseservicereporter_controller.go
+++ b/controllers/ibmlicenseservicereporter_controller.go
@@ -118,7 +118,9 @@ func (r *IBMLicenseServiceReporterReconciler) Reconcile(req reconcile.Request) (
 		r.reconcileOperandBindInfo,
 		r.reconcileOidcCredentials,
 		r.reconcileDeployment,
-		r.reconcileReporterRoute,
+		r.reconcileReporterRouteWithoutCertificates,
+		r.reconcileCertificateSecrets,
+		r.reconcileReporterRouteWithCertificates,
 		r.reconcileUIIngress,
 		r.reconcileIngressProxy,
 		r.reconcileSenderConfiguration,
@@ -397,20 +399,167 @@ func (r *IBMLicenseServiceReporterReconciler) reconcileDeployment(instance *oper
 	return reconcile.Result{}, nil
 }
 
-func (r *IBMLicenseServiceReporterReconciler) reconcileReporterRoute(instance *operatorv1alpha1.IBMLicenseServiceReporter) (reconcile.Result, error) {
-	if res.IsRouteAPI {
-		expectedRoute := reporter.GetReporterRoute(instance)
-		foundRoute := &routev1.Route{}
-		namespacedName := types.NamespacedName{Name: expectedRoute.GetName(), Namespace: expectedRoute.GetNamespace()}
-		reconcileResult, err := r.reconcileResourceExistence(instance, expectedRoute, foundRoute, namespacedName)
+func (r *IBMLicenseServiceReporterReconciler) reconcileCertificateSecrets(instance *operatorv1alpha1.IBMLicenseServiceReporter) (reconcile.Result, error) {
+	// for backward compatibility, we treat the "ocp" HTTPSCertsSource same as "self-signed"
+	if res.IsRouteAPI && instance.Spec.HTTPSCertsSource != "custom" {
+		ocpExternalCertSecret := &corev1.Secret{}
+		r.Log.Info("Reconciling external certificate")
+		namespacedName := types.NamespacedName{Namespace: instance.GetNamespace(), Name: reporter.LicenseReportExternalCertName}
+		routeNamespacedName := types.NamespacedName{Namespace: instance.GetNamespace(), Name: reporter.LicenseReporterResourceBase}
 
+		route := &routev1.Route{}
+		if err := r.Client.Get(context.TODO(), routeNamespacedName, route); err != nil {
+			r.Log.Error(err, "Cannot get route")
+			return reconcile.Result{Requeue: true}, err
+		}
+
+		if err := r.Client.Get(context.TODO(), namespacedName, ocpExternalCertSecret); err != nil {
+			r.Log.WithValues("external cert name", namespacedName).Info("external certificate secret not existing. Generating self signed certificate")
+
+			secret, err := r.getSelfSignedCertWithOwnerReference(instance, namespacedName, []string{route.Spec.Host})
+			if err != nil {
+				r.Log.Error(err, "Error generating self signed certificate")
+				return reconcile.Result{Requeue: true}, err
+			}
+
+			if err := r.Client.Create(context.TODO(), secret); err != nil {
+				r.Log.Error(err, "Error creating self signed certificate")
+				return reconcile.Result{Requeue: true}, err
+			}
+		} else {
+			// checking certificate
+			cert, err := res.ParseCertificate(ocpExternalCertSecret.Data["tls.crt"])
+			reqLogger := r.Log.WithValues("reconcileCertificate", "Entry", "instance.GetName()", instance.GetName())
+
+			// if improper x509 certificate
+			if err != nil {
+				r.Log.Error(err, "Improper x509 certificate in secret, regenrating certificate")
+				secret, err := r.getSelfSignedCertWithOwnerReference(instance, namespacedName, []string{route.Spec.Host})
+				if err != nil {
+					r.Log.Error(err, "Error creating self signed certificate")
+					return reconcile.Result{Requeue: true}, err
+
+				}
+				return res.UpdateResource(&reqLogger, r.Client, secret, ocpExternalCertSecret)
+			}
+
+			// if certificate is expired
+			if cert.NotAfter.Before(time.Now().AddDate(0, -90, 0)) {
+				r.Log.Info("Self signed certificate has expired. Generating new certificate")
+				secret, err := r.getSelfSignedCertWithOwnerReference(instance, namespacedName, []string{route.Spec.Host})
+				if err != nil {
+					r.Log.Error(err, "Error creating self signed certificate")
+					return reconcile.Result{Requeue: true}, err
+
+				}
+				return res.UpdateResource(&reqLogger, r.Client, secret, ocpExternalCertSecret)
+			}
+
+			// if certificate is not issued to the route host
+			if err := cert.VerifyHostname(route.Spec.Host); err != nil {
+				r.Log.Info("Certificate not issued to a propper hostname. Generating new self-signed certificate")
+				secret, err := r.getSelfSignedCertWithOwnerReference(instance, namespacedName, []string{route.Spec.Host})
+				if err != nil {
+					r.Log.Error(err, "Error creating self signed certificate")
+					return reconcile.Result{Requeue: true}, err
+
+				}
+				return res.UpdateResource(&reqLogger, r.Client, secret, ocpExternalCertSecret)
+			}
+
+		}
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (r *IBMLicenseServiceReporterReconciler) reconcileReporterRouteWithoutCertificates(instance *operatorv1alpha1.IBMLicenseServiceReporter) (reconcile.Result, error) {
+	if res.IsRouteAPI {
+		routeNamespacedName := types.NamespacedName{Namespace: instance.GetNamespace(), Name: reporter.LicenseReporterResourceBase}
+		route := &routev1.Route{}
+		if err := r.Client.Get(context.TODO(), routeNamespacedName, route); err != nil {
+			r.Log.Info("Route does not exist, reconciling route without certificates")
+
+			defaultRouteTLS := &routev1.TLSConfig{
+				Termination:                   routev1.TLSTerminationReencrypt,
+				InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyNone,
+			}
+			return r.reconcileRouteWithTLS(instance, defaultRouteTLS)
+		}
+	}
+	return reconcile.Result{}, nil
+}
+
+func (r *IBMLicenseServiceReporterReconciler) reconcileReporterRouteWithCertificates(instance *operatorv1alpha1.IBMLicenseServiceReporter) (reconcile.Result, error) {
+	if res.IsRouteAPI {
+		r.Log.Info("Reconciling route with certificate")
+		externalCertSecret := corev1.Secret{}
+		var externalCertName string
+		if instance.Spec.HTTPSCertsSource == "custom" {
+			externalCertName = reporter.LicenseReportCustomExternalCertName
+		} else {
+			externalCertName = reporter.LicenseReportExternalCertName
+		}
+
+		externalNamespacedName := types.NamespacedName{Namespace: instance.GetNamespace(), Name: externalCertName}
+		if err := r.Client.Get(context.TODO(), externalNamespacedName, &externalCertSecret); err != nil {
+			r.Log.Error(err, "Cannot retrieve external certificate from secret")
+			return reconcile.Result{Requeue: true}, nil
+		}
+
+		internalCertSecret := corev1.Secret{}
+		internalNamespacedName := types.NamespacedName{Namespace: instance.GetNamespace(), Name: reporter.LicenseReportOCPCertName}
+		if err := r.Client.Get(context.TODO(), internalNamespacedName, &internalCertSecret); err != nil {
+			r.Log.Error(err, "Cannot retrieve external certificate from secret")
+			return reconcile.Result{Requeue: true}, nil
+		}
+
+		cert, caCert, key, err := res.ProcessCerfiticateSecret(externalCertSecret)
+		if err != nil {
+			r.Log.Error(err, "Invalid certificate format in secret, retrying")
+			return reconcile.Result{Requeue: true, RequeueAfter: 30 * time.Second}, err
+		}
+		_, destinationCaCert, _, err := res.ProcessCerfiticateSecret(internalCertSecret)
+		if err != nil {
+			r.Log.Error(err, "Invalid certificate format in secret, retrying")
+			return reconcile.Result{Requeue: true, RequeueAfter: 30 * time.Second}, err
+		}
+
+		defaultRouteTLS := &routev1.TLSConfig{
+			Termination:                   routev1.TLSTerminationReencrypt,
+			InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyNone,
+			Certificate:                   cert,
+			CACertificate:                 caCert,
+			Key:                           key,
+			DestinationCACertificate:      destinationCaCert,
+		}
+		return r.reconcileRouteWithTLS(instance, defaultRouteTLS)
+	}
+	return reconcile.Result{}, nil
+}
+
+func (r *IBMLicenseServiceReporterReconciler) reconcileRouteWithTLS(instance *operatorv1alpha1.IBMLicenseServiceReporter, defaultRouteTLS *routev1.TLSConfig) (reconcile.Result, error) {
+	if res.IsRouteAPI {
+		expectedRoute := reporter.GetReporterRoute(instance, defaultRouteTLS)
+		foundRoute := &routev1.Route{}
+		reconcileResult, err := r.reconcileResourceNamespacedExistence(instance, expectedRoute, foundRoute)
 		if err != nil || reconcileResult.Requeue {
 			return reconcileResult, err
 		}
 		reqLogger := r.Log.WithValues("reconcileRoute", "Entry", "instance.GetName()", instance.GetName())
 
 		if !res.CompareRoutes(reqLogger, expectedRoute, foundRoute) {
-			return res.UpdateResource(&reqLogger, r.Client, expectedRoute, foundRoute)
+			//route tls cannot be updated, that is why we delete and create
+			reconcileResult, err = res.DeleteResource(&reqLogger, r.Client, foundRoute)
+			if err != nil {
+				return reconcileResult, err
+			}
+			time.Sleep(time.Second * 10)
+			foundRoute = &routev1.Route{}
+			reconcileResult, err = r.reconcileResourceNamespacedExistence(instance, expectedRoute, foundRoute)
+			if err != nil || reconcileResult.Requeue {
+				return reconcileResult, err
+			}
 		}
 	}
 	return reconcile.Result{}, nil
@@ -477,6 +626,13 @@ func (r *IBMLicenseServiceReporterReconciler) reconcileResourceExistence(
 	return reconcile.Result{}, nil
 }
 
+func (r *IBMLicenseServiceReporterReconciler) reconcileResourceNamespacedExistence(
+	instance *operatorv1alpha1.IBMLicenseServiceReporter, expectedRes res.ResourceObject, foundRes runtime.Object) (reconcile.Result, error) {
+
+	namespacedName := types.NamespacedName{Name: expectedRes.GetName(), Namespace: expectedRes.GetNamespace()}
+	return r.reconcileResourceExistence(instance, expectedRes, foundRes, namespacedName)
+}
+
 func (r *IBMLicenseServiceReporterReconciler) controllerStatus() {
 	if res.IsRouteAPI {
 		r.Log.Info("Route feature is enabled")
@@ -493,4 +649,21 @@ func (r *IBMLicenseServiceReporterReconciler) controllerStatus() {
 	} else {
 		r.Log.Info("ODLM is unavailable")
 	}
+}
+
+func (r *IBMLicenseServiceReporterReconciler) getSelfSignedCertWithOwnerReference(
+	instance *operatorv1alpha1.IBMLicenseServiceReporter,
+	namespacedName types.NamespacedName,
+	dns []string) (*corev1.Secret, error) {
+
+	secret, err := res.GenerateSelfSignedCertSecret(namespacedName, dns)
+	if err != nil {
+		r.Log.Error(err, "Error when generating self signed certificate")
+	}
+	err = controllerutil.SetControllerReference(instance, secret, r.Scheme)
+	if err != nil {
+		r.Log.Error(err, "Failed to set owner reference in secret")
+		return nil, err
+	}
+	return secret, nil
 }

--- a/controllers/resources/reporter/helper.go
+++ b/controllers/resources/reporter/helper.go
@@ -55,7 +55,9 @@ const LicenseReporterUIBase = "ibm-license-service-reporter-ui"
 const LicenseReporterResourceBase = "ibm-license-service-reporter"
 const LicenseReporterComponentName = "ibm-license-service-reporter-svc"
 const LicenseReporterReleaseName = "ibm-license-service-reporter"
-const LicenseReportOCPCertName = "ibm-license-reporter-cert"
+const LicenseReportOCPCertName = "ibm-license-reporter-cert-internal"
+const LicenseReportExternalCertName = "ibm-license-reporter-cert"
+const LicenseReportCustomExternalCertName = "ibm-licensing-reporter-certs"
 
 const OperatorName = "ibm-licensing-operator"
 

--- a/controllers/resources/reporter/routing.go
+++ b/controllers/resources/reporter/routing.go
@@ -24,12 +24,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func GetReporterRoute(instance *operatorv1alpha1.IBMLicenseServiceReporter) *routev1.Route {
-
+func GetReporterRoute(instance *operatorv1alpha1.IBMLicenseServiceReporter, defaultRouteTLS *routev1.TLSConfig) *routev1.Route {
 	var tls *routev1.TLSConfig
-	defaultRouteTLS := &routev1.TLSConfig{
-		Termination: routev1.TLSTerminationPassthrough,
-	}
+
 	if instance.Spec.RouteOptions != nil {
 		if instance.Spec.RouteOptions.TLS != nil {
 			tls = instance.Spec.RouteOptions.TLS

--- a/controllers/resources/reporter/volumes.go
+++ b/controllers/resources/reporter/volumes.go
@@ -96,7 +96,8 @@ func getLicenseServiceReporterVolumes(spec operatorv1alpha1.IBMLicenseServiceRep
 		},
 	}
 
-	volumes = append(volumes, resources.GetVolume(LicenseReporterHTTPSCertsVolumeName, LicenseReportOCPCertName))
-
+	if resources.IsServiceCAAPI {
+		volumes = append(volumes, resources.GetVolume(LicenseReporterHTTPSCertsVolumeName, LicenseReportOCPCertName))
+	}
 	return volumes
 }


### PR DESCRIPTION
* switch default route to reencrypt

* provide external certificate to a route

* add self-sign cert generation and rotation

* generate certificate specifically for route host

* add ownership reference to secret, cleanup code, handle more edgecases

* dummy change

* Fix linter

* linter fix

* fix fips not possible to update tls in route

* fix fips not having custom host role

* fips route reconcile decrease cooldown to 10s

* Fix population of route with custom certificate

* Fix logic error in CompareRoutes function

* Fix handling of certificate volumes in LS pod

* Fix logic error in CompareRoutes function

* change certificate validity period to 1 year

* Fixed typo in the output log

* move parsing certificate to common code

* Check external certificate hostname

* FIPS logic for self-signed external certificate for LSR

* Allow custom certificate on LSR

* Always annotate service in OCP

* Fix linter

Co-authored-by: SzymonKowalczyk <szymon.kowalczyk@pl.ibm.com>
Co-authored-by: adam <Adam.Dyszy@ibm.com>
Co-authored-by: Jan Olszowka <jan.olszowka@ibm.com>