### PR TITLE
Enable certificate generation when ingress is enabled

### DIFF
--- a/controllers/ibmlicensing_controller.go
+++ b/controllers/ibmlicensing_controller.go
@@ -569,6 +569,12 @@ func (r *IBMLicensingReconciler) reconcileCertificateSecrets(instance *operatorv
 		namespacedName = types.NamespacedName{Namespace: instance.Spec.InstanceNamespace, Name: service.LicenseServiceExternalCertName}
 		hostname = []string{route.Spec.Host}
 		rolloutPods = false
+	} else {
+		// skip certificate creation only for OCP environment if route is disabled
+		if res.IsServiceCAAPI {
+			r.Log.Info("Skipping certificate creation for OCP - route is disabled via configuration")
+			return reconcile.Result{}, nil
+		}
 	}
 
 	// Reconcile internal certificate only on non-OCP environments

--- a/controllers/ibmlicensing_controller.go
+++ b/controllers/ibmlicensing_controller.go
@@ -411,7 +411,7 @@ func (r *IBMLicensingReconciler) reconcileConfigMaps(instance *operatorv1alpha1.
 			return reconcile.Result{Requeue: true}, err
 		}
 
-		// Skip verification of certificates route/ingress Route is disabled
+		// Skip verification of certificates when route/ingress is disabled
 		return reconcile.Result{}, nil
 	}
 

--- a/controllers/ibmlicensing_controller.go
+++ b/controllers/ibmlicensing_controller.go
@@ -730,6 +730,7 @@ func (r *IBMLicensingReconciler) reconcileIngress(instance *operatorv1alpha1.IBM
 			return res.UpdateResource(&reqLogger, r.Client, expectedIngress, foundIngress)
 		}
 	} else {
+		r.Log.Info("Ingress is disabled, deleting current ingress if exists")
 		reconcileResult, err := r.reconcileNamespacedResourceWhichShouldNotExist(instance, expectedIngress, foundIngress)
 		if err != nil || reconcileResult.Requeue {
 			return reconcileResult, err


### PR DESCRIPTION
## Changes

Fix certificate secrets not generating when ingress is enabled (non ocp envs).

## Parent issue

internal

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which modifies existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Manual tests
- [ ] Automated sert tests: <sert logs url>
