### PR TITLE
capture the error from make unit-test

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -23,6 +23,7 @@ on:
   push:
       branches:
         - master
+        - release-ltsr
 
 env:
   GO_VERSION: "1.20.5"
@@ -126,7 +127,7 @@ jobs:
         export PATH=`pwd`:$PATH
         export SUFIX=$RANDOM
         export USE_EXISTING_CLUSTER=true
-        make unit-test | tee ./unittest_logs_${{ matrix.k8s }}.txt 2>&1
+        make unit-test | tee ./unittest_logs_${{ matrix.k8s }}.txt 2>&1 || exit 1
 
     - name: Check all pods
       if: always()

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -127,7 +127,7 @@ jobs:
         export PATH=`pwd`:$PATH
         export SUFIX=$RANDOM
         export USE_EXISTING_CLUSTER=true
-        make unit-test | tee ./unittest_logs_${{ matrix.k8s }}.txt 2>&1 || exit 1
+        make unit-test | tee ./unittest_logs_${{ matrix.k8s }}.txt 2>&1 || { exit_code=$?; echo "Command exited with an error $exit_code"; exit $exit_code; }
 
     - name: Check all pods
       if: always()

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -127,8 +127,8 @@ jobs:
         export PATH=`pwd`:$PATH
         export SUFIX=$RANDOM
         export USE_EXISTING_CLUSTER=true
-        make unit-test | tee ./unittest_logs_${{ matrix.k8s }}.txt 2>&1 
-        exit_code=$?; echo "Command exited with an error $exit_code"; exit $exit_code;
+        set -o pipefail
+        make unit-test 2>&1 | tee ./unittest_logs_${{ matrix.k8s }}.txt
 
     - name: Check all pods
       if: always()

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -127,7 +127,8 @@ jobs:
         export PATH=`pwd`:$PATH
         export SUFIX=$RANDOM
         export USE_EXISTING_CLUSTER=true
-        make unit-test | tee ./unittest_logs_${{ matrix.k8s }}.txt 2>&1 || { exit_code=$?; echo "Command exited with an error $exit_code"; exit $exit_code; }
+        make unit-test | tee ./unittest_logs_${{ matrix.k8s }}.txt 2>&1 
+        exit_code=$?; echo "Command exited with an error $exit_code"; exit $exit_code;
 
     - name: Check all pods
       if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,4 @@ tags
 .idea
 .go/*
 bin/
+vendor/

--- a/controllers/ibmlicensing_controller_test.go
+++ b/controllers/ibmlicensing_controller_test.go
@@ -255,7 +255,7 @@ var _ = Describe("IBMLicensing controller", func() {
 				prometheusService := &v1.Service{}
 				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: service.GetPrometheusServiceName(), Namespace: namespace}, prometheusService)).Should(Succeed())
 				return prometheusService != nil
-			}, timeout, interval).Should(BeFalse()) //mock error
+			}, timeout, interval).Should(BeTrue())
 
 			By("Checking if service monitor exists")
 			Eventually(func() bool {

--- a/controllers/ibmlicensing_controller_test.go
+++ b/controllers/ibmlicensing_controller_test.go
@@ -255,7 +255,7 @@ var _ = Describe("IBMLicensing controller", func() {
 				prometheusService := &v1.Service{}
 				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: service.GetPrometheusServiceName(), Namespace: namespace}, prometheusService)).Should(Succeed())
 				return prometheusService != nil
-			}, timeout, interval).Should(BeTrue())
+			}, timeout, interval).Should(BeFalse()) //mock error
 
 			By("Checking if service monitor exists")
 			Eventually(func() bool {


### PR DESCRIPTION
## Changes

Make github action workflow fails if make unit-test exits with error code 1.

```
FAIL	github.com/IBM/ibm-licensing-operator/controllers	600.041s
FAIL
make: *** [Makefile:330: unit-test] Error 1
```
Even though the make exits with error, the workflow is successful, it should also fail.

## Parent issue

https://github.ibm.com/IBMPrivateCloud/roadmap/issues/<issue number>

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which modifies existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] Manual tests
- [ ] Automated sert tests: <sert logs url>