### PR TITLE
Add checking exit code check in pipeline

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -125,7 +125,7 @@ jobs:
         export SUFIX=$RANDOM
         export USE_EXISTING_CLUSTER=true
         set -o pipefail
-        make unit-test | tee ./unittest_logs_${{ matrix.k8s }}.txt 2>&1
+        make unit-test 2>&1 | tee ./unittest_logs_${{ matrix.k8s }}.txt
 
     - name: Check all pods
       if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,4 @@ tags
 .go/*
 bin/
 .DS_Store
+vendor/


### PR DESCRIPTION
## Changes

Make github action workflow fails if make unit-test exits with error code 1.

```
FAIL	github.com/IBM/ibm-licensing-operator/controllers	600.041s
FAIL
make: *** [Makefile:330: unit-test] Error 1
```
Even though the make exits with error, the workflow is successful, it should also fail.

## Parent issue

https://github.ibm.com/IBMPrivateCloud/roadmap/issues/<issue number>

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which modifies existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] Manual tests
- [ ] Automated sert tests: <sert logs url>