### PR TITLE
rename lsr token secret

### DIFF
--- a/api/v1alpha1/helper.go
+++ b/api/v1alpha1/helper.go
@@ -31,8 +31,8 @@ import (
 )
 
 const localReporterURL = "https://ibm-license-service-reporter:8080"
-const defaultLicensingTokenSecretName = "ibm-licensing-token"         //#nosec
-const defaultReporterTokenSecretName = "ibm-licensing-reporter-token" //#nosec
+const defaultLicensingTokenSecretName = "ibm-licensing-token"               //#nosec
+const defaultReporterTokenSecretName = "ibm-license-service-reporter-token" // secret used by LS to push data to LSR
 const OperandLicensingImageEnvVar = "IBM_LICENSING_IMAGE"
 const OperandUsageImageEnvVar = "IBM_LICENSING_USAGE_IMAGE"
 


### PR DESCRIPTION
Rename secret holding token used to upload data to the IBM License Service Reporter (in line with changes with IBM License Service Reporter Operator).