### PR TITLE
Add check for the nil Spec - avoid nullpointer

### DIFF
--- a/controllers/ibmlicensing_controller_test.go
+++ b/controllers/ibmlicensing_controller_test.go
@@ -19,7 +19,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"time"
 
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	. "github.com/onsi/ginkgo/v2"
@@ -117,13 +116,12 @@ var _ = Describe("IBMLicensing controller", Ordered, func() {
 			newInstance := &operatorv1alpha1.IBMLicensing{}
 			events := &v1.EventList{}
 
-			time.Sleep(30 * time.Second)
-
 			By("Checking if license is not accepted")
 			Eventually(func() bool {
-				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: instance.Name}, newInstance)).Should(Succeed())
-				fmt.Println(newInstance)
-				return newInstance.Spec.IsLicenseAccepted()
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: instance.Name}, newInstance); err != nil {
+					return newInstance.Spec.IsLicenseAccepted()
+				}
+				return true
 			}, timeout, interval).Should(Equal(false))
 
 			By("Checking if 'license not accepted' event was created successfully")

--- a/controllers/ibmlicensing_controller_test.go
+++ b/controllers/ibmlicensing_controller_test.go
@@ -119,9 +119,9 @@ var _ = Describe("IBMLicensing controller", Ordered, func() {
 			By("Checking if license is not accepted")
 			Eventually(func() bool {
 				if err := k8sClient.Get(ctx, types.NamespacedName{Name: instance.Name}, newInstance); err != nil {
-					return newInstance.Spec.IsLicenseAccepted()
+					return true
 				}
-				return true
+				return newInstance.Spec.IsLicenseAccepted()
 			}, timeout, interval).Should(Equal(false))
 
 			By("Checking if 'license not accepted' event was created successfully")

--- a/controllers/ibmlicensing_controller_test.go
+++ b/controllers/ibmlicensing_controller_test.go
@@ -119,10 +119,8 @@ var _ = Describe("IBMLicensing controller", Ordered, func() {
 			By("Checking if license is not accepted")
 			Eventually(func() bool {
 				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: instance.Name}, newInstance)).Should(Succeed())
-				if newInstance.Spec != nil {
-					return newInstance.Spec.IsLicenseAccepted()
-				}
-				return true
+				fmt.Println(newInstance)
+				return newInstance.Spec.IsLicenseAccepted()
 			}, timeout, interval).Should(Equal(false))
 
 			By("Checking if 'license not accepted' event was created successfully")

--- a/controllers/ibmlicensing_controller_test.go
+++ b/controllers/ibmlicensing_controller_test.go
@@ -119,7 +119,10 @@ var _ = Describe("IBMLicensing controller", Ordered, func() {
 			By("Checking if license is not accepted")
 			Eventually(func() bool {
 				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: instance.Name}, newInstance)).Should(Succeed())
-				return newInstance.Spec.IsLicenseAccepted()
+				if newInstance.Spec != nil {
+					return newInstance.Spec.IsLicenseAccepted()
+				}
+				return true
 			}, timeout, interval).Should(Equal(false))
 
 			By("Checking if 'license not accepted' event was created successfully")

--- a/controllers/ibmlicensing_controller_test.go
+++ b/controllers/ibmlicensing_controller_test.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"time"
 
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	. "github.com/onsi/ginkgo/v2"
@@ -118,6 +119,7 @@ var _ = Describe("IBMLicensing controller", Ordered, func() {
 
 			By("Checking if license is not accepted")
 			Eventually(func() bool {
+				time.Sleep(60 * time.Second)
 				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: instance.Name}, newInstance)).Should(Succeed())
 				fmt.Println(newInstance)
 				return newInstance.Spec.IsLicenseAccepted()

--- a/controllers/ibmlicensing_controller_test.go
+++ b/controllers/ibmlicensing_controller_test.go
@@ -117,9 +117,10 @@ var _ = Describe("IBMLicensing controller", Ordered, func() {
 			newInstance := &operatorv1alpha1.IBMLicensing{}
 			events := &v1.EventList{}
 
+			time.Sleep(30 * time.Second)
+
 			By("Checking if license is not accepted")
 			Eventually(func() bool {
-				time.Sleep(60 * time.Second)
 				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: instance.Name}, newInstance)).Should(Succeed())
 				fmt.Println(newInstance)
 				return newInstance.Spec.IsLicenseAccepted()


### PR DESCRIPTION
## Changes

Fix kind test failing because of the 404 error when executing k8s.get() on non-existing resource. Check if resource exist in the loop instead of failing.

## Parent issue

NaN

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which modifies existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Enhancement (improves testing strategy, tidy code, CICD update)
- [ ] Dependency/version upgrade/CVE
- [ ] This change requires a documentation update

# How has it been tested?

- [x] Manual tests
- [ ] Automated sert tests: <sert logs url>

# Test images (if applicable):
-
-