### PR TITLE
fix operator not reconciling reporter upload token secret name for LS

### DIFF
--- a/controllers/resources/deployments.go
+++ b/controllers/resources/deployments.go
@@ -47,10 +47,11 @@ func equalEnvVars(envVarArr1, envVarArr2 []corev1.EnvVar) bool {
 	if len(envVarArr1) != len(envVarArr2) {
 		return false
 	}
+
 	for _, env1 := range envVarArr1 {
 		contains := false
 		for _, env2 := range envVarArr2 {
-			if env1.Name == env2.Name && env1.Value == env2.Value {
+			if env1.Name == env2.Name && env1.Value == env2.Value && reflect.DeepEqual(env1.ValueFrom, env2.ValueFrom) {
 				contains = true
 				break
 			}

--- a/controllers/resources/deployments_test.go
+++ b/controllers/resources/deployments_test.go
@@ -1,0 +1,54 @@
+//
+// Copyright 2023 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package resources
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/IBM/ibm-licensing-operator/testutils"
+)
+
+func TestEqualsEnvVars(t *testing.T) {
+	type args struct {
+		envVars1 []corev1.EnvVar
+		envVars2 []corev1.EnvVar
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{"Equal env vars - empty", args{envVars1: []corev1.EnvVar{}, envVars2: []corev1.EnvVar{}}, true},
+		{"Equal env vars", args{envVars1: testutils.Envs1, envVars2: testutils.Envs1}, true},
+		{"Equal vars - with value refs", args{envVars1: testutils.Envs6, envVars2: testutils.Envs6}, true},
+		{"Not equal env vars - different lengths", args{envVars1: testutils.Envs1, envVars2: testutils.Envs2}, false},
+		{"Not equal env vars - different values", args{envVars1: testutils.Envs1, envVars2: testutils.Envs5}, false},
+		{"Not equal env vars", args{envVars1: testutils.Envs1, envVars2: testutils.Envs3}, false},
+		{"Not equal env vars - missing value ref", args{envVars1: testutils.Envs1, envVars2: testutils.Envs6}, false},
+		{"Not equal env vars - different value ref", args{envVars1: testutils.Envs6, envVars2: testutils.Envs7}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := equalEnvVars(tt.args.envVars1, tt.args.envVars2); got != tt.want {
+				t.Errorf("equalEnvVars() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+
+}

--- a/testutils/mocks.go
+++ b/testutils/mocks.go
@@ -1,0 +1,51 @@
+//
+// Copyright 2023 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package testutils
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+var Envs1 = []corev1.EnvVar{
+	{Name: "env1", Value: "val1"},
+	{Name: "env2", Value: "env2"},
+}
+
+var Envs2 = []corev1.EnvVar{
+	{Name: "env1", Value: "val1"},
+	{Name: "env2", Value: "env2"},
+	{Name: "env3", Value: "env3"},
+}
+
+var Envs3 = []corev1.EnvVar{
+	{Name: "env", Value: "val"},
+}
+
+var Envs5 = []corev1.EnvVar{
+	{Name: "env1", Value: "val3"},
+	{Name: "env2", Value: "env2"},
+}
+
+var Envs6 = []corev1.EnvVar{
+	{Name: "env1", Value: "val1"},
+	{Name: "env2", Value: "env2", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "secret-a"}}}},
+}
+
+var Envs7 = []corev1.EnvVar{
+	{Name: "env1", Value: "val1"},
+	{Name: "env2", Value: "env2", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "secret-b"}}}},
+}


### PR DESCRIPTION
Fix operator not reconciling change of the Reporter upload token secret name, used by the License Service.