### PR TITLE
Update Meter Definition to expose Services breakdown, including the new top-level product id

### DIFF
--- a/controllers/resources/service/meter_definition.go
+++ b/controllers/resources/service/meter_definition.go
@@ -146,7 +146,7 @@ func getServiceMeterDefinition(instance *operatorv1alpha1.IBMLicensing) *rhmp.Me
 					WorkloadType:       rhmpcommon.WorkloadTypeService,
 					Metric:             "{{ .Label.parentMetricId}}",
 					Query:              "avg_over_time(cp4d_capability{}[1d])",
-					GroupBy:            []string{"metricId", "productId", "parentMetricId", "parentProductId", "topLevelProductId"},
+					GroupBy:            []string{"metricId", "productId", "parentMetricId", "parentProductId", "topLevelProductId", "topLevelMetricId"},
 					ValueLabelOverride: "{{ .Label.value}}",
 					DateLabelOverride:  "{{ .Label.date}}",
 				},

--- a/controllers/resources/service/meter_definition.go
+++ b/controllers/resources/service/meter_definition.go
@@ -122,8 +122,8 @@ func getServiceMeterDefinition(instance *operatorv1alpha1.IBMLicensing) *rhmp.Me
 			Namespace: instance.Spec.InstanceNamespace,
 		},
 		Spec: rhmp.MeterDefinitionSpec{
-			Group: "{{ .Label.productId}}.adoption.ibm.com",
-			Kind:  "IBMAdoption",
+			Group: "{{ .Label.productId}}.licensing.ibm.com",
+			Kind:  "IBMLicensing-Service",
 			ResourceFilters: []rhmp.ResourceFilter{
 				{
 					Namespace: &rhmp.NamespaceFilter{
@@ -146,7 +146,7 @@ func getServiceMeterDefinition(instance *operatorv1alpha1.IBMLicensing) *rhmp.Me
 					WorkloadType:       rhmpcommon.WorkloadTypeService,
 					Metric:             "{{ .Label.parentMetricId}}",
 					Query:              "avg_over_time(cp4d_capability{}[1d])",
-					GroupBy:            []string{"metricId", "productId", "parentMetricId", "parentProductId"},
+					GroupBy:            []string{"metricId", "productId", "parentMetricId", "parentProductId", "topLevelProductId"},
 					ValueLabelOverride: "{{ .Label.value}}",
 					DateLabelOverride:  "{{ .Label.date}}",
 				},


### PR DESCRIPTION
The associated change in the LicSvc operand is https://github.ibm.com/cloud-license-reporter/cloud-reporter/pull/531 - i.e. the Services breakdown is no longer represented as an adoption metric, but a license metric breakdown.

The resulting `MeterDefintion` shall look like:


```yaml
spec:
  group: '{{ .Label.productId}}.licensing.ibm.com'
  kind: IBMLicensing-Service
  meters:
    - period: 24h0m0s
      aggregation: max
      query: 'avg_over_time(cp4d_capability{}[1d])'
      name: Cp4d Capability
      metricId: '{{ .Label.parentMetricId}}'
      valueLabelOverride: '{{ .Label.value}}'
      workloadType: Service
      dateLabelOverride: '{{ .Label.date}}'
      groupBy:
        - metricId
        - productId
        - parentMetricId
        - parentProductId
        - topLevelProductId
        - topLevelMetricId
```
