### PR TITLE
Add spec labels support

### DIFF
--- a/api/v1alpha1/ibmlicensing_types.go
+++ b/api/v1alpha1/ibmlicensing_types.go
@@ -148,6 +148,11 @@ type IBMLicensingSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Features"
 	// +optional
 	Features *Features `json:"features,omitempty"`
+
+	// Labels to be copied into all relevant resources
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Labels"
+	// +optional
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 type IBMLicensingSenderSpec struct {

--- a/bundle/manifests/ibm-licensing-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-licensing-operator.clusterserviceversion.yaml
@@ -27,7 +27,7 @@ metadata:
     categories: Monitoring
     certified: "false"
     containerImage: icr.io/cpopen/ibm-licensing-operator:4.2.1
-    createdAt: "2023-09-18T15:08:56Z"
+    createdAt: "2023-10-27T10:09:06Z"
     description: The IBM Licensing Operator provides a Kubernetes CRD-Based API to monitor the license usage of products.
     nss.operator.ibm.com/managed-operators: ibm-licensing-operator-app
     olm.skipRange: '>=1.0.0 <4.2.1'

--- a/bundle/manifests/operator.ibm.com_ibmlicensings.yaml
+++ b/bundle/manifests/operator.ibm.com_ibmlicensings.yaml
@@ -214,6 +214,11 @@ spec:
                   will start. In case metering data collection is used, should be
                   the same namespace as metering components
                 type: string
+              labels:
+                additionalProperties:
+                  type: string
+                description: Labels to be copied into all relevant resources
+                type: object
               license:
                 description: IBM License Service license acceptance.
                 properties:

--- a/config/crd/bases/operator.ibm.com_ibmlicensings.yaml
+++ b/config/crd/bases/operator.ibm.com_ibmlicensings.yaml
@@ -211,6 +211,11 @@ spec:
                   will start. In case metering data collection is used, should be
                   the same namespace as metering components
                 type: string
+              labels:
+                additionalProperties:
+                  type: string
+                description: Labels to be copied into all relevant resources
+                type: object
               license:
                 description: IBM License Service license acceptance.
                 properties:

--- a/controllers/ibmlicensing_controller.go
+++ b/controllers/ibmlicensing_controller.go
@@ -376,7 +376,7 @@ Should be called either before any `Get` calls, such as the resource existence c
 In its current state, may be somewhat costly in terms of performance. Copy and `UpdateResources` calls can be replaced
 with an `Update` call on the resource if needed.
 */
-// TODO: Missing: ibm-licensing-service-prometheus-cert, ibm-license-service-cert-internal
+// TODO: Missing: ibm-licensing-service-prometheus-cert
 func (r *IBMLicensingReconciler) maybeAttachSpecLabels(
 	instance *operatorv1alpha1.IBMLicensing,
 	resource res.ResourceObject,
@@ -558,6 +558,11 @@ func (r *IBMLicensingReconciler) reconcileConfigMaps(instance *operatorv1alpha1.
 
 		// Skip verification of certificates when route/ingress is disabled
 		return reconcile.Result{}, nil
+	}
+
+	result, err := r.maybeAttachSpecLabels(instance, internalCertificate, &reqLogger)
+	if err != nil || result.Requeue {
+		return result, err
 	}
 
 	expectedCMs := []*corev1.ConfigMap{

--- a/controllers/resources/deployments.go
+++ b/controllers/resources/deployments.go
@@ -23,6 +23,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+// To make linter happy
+const containerErrorMessageStart = "Container "
+
 func equalProbes(probe1 *corev1.Probe, probe2 *corev1.Probe) bool {
 	if probe1 == nil {
 		return probe2 == nil
@@ -118,31 +121,31 @@ func equalContainerLists(reqLogger *logr.Logger, containers1 []corev1.Container,
 		}
 		potentialDifference = true
 		if foundContainer.Image != expectedContainer.Image {
-			(*reqLogger).Info("Container " + foundContainer.Name + " wrong container image")
+			(*reqLogger).Info(containerErrorMessageStart + foundContainer.Name + " wrong container image")
 		} else if foundContainer.ImagePullPolicy != expectedContainer.ImagePullPolicy {
-			(*reqLogger).Info("Container " + foundContainer.Name + " wrong image pull policy")
+			(*reqLogger).Info(containerErrorMessageStart + foundContainer.Name + " wrong image pull policy")
 		} else if !reflect.DeepEqual(foundContainer.Command, expectedContainer.Command) {
-			(*reqLogger).Info("Container " + foundContainer.Name + " wrong container command")
+			(*reqLogger).Info(containerErrorMessageStart + foundContainer.Name + " wrong container command")
 		} else if !reflect.DeepEqual(foundContainer.Ports, expectedContainer.Ports) {
-			(*reqLogger).Info("Container " + foundContainer.Name + " wrong containers ports")
+			(*reqLogger).Info(containerErrorMessageStart + foundContainer.Name + " wrong containers ports")
 		} else if !reflect.DeepEqual(foundContainer.VolumeMounts, expectedContainer.VolumeMounts) {
-			(*reqLogger).Info("Container " + foundContainer.Name + " wrong VolumeMounts in container")
+			(*reqLogger).Info(containerErrorMessageStart + foundContainer.Name + " wrong VolumeMounts in container")
 		} else if !equalEnvVars(foundContainer.Env, expectedContainer.Env) { // DeepEqual requires same order of items, which results in false negatives, so we use custom comparison function
-			(*reqLogger).Info("Container " + foundContainer.Name + " wrong env variables in container")
+			(*reqLogger).Info(containerErrorMessageStart + foundContainer.Name + " wrong env variables in container")
 		} else if !reflect.DeepEqual(foundContainer.SecurityContext, expectedContainer.SecurityContext) {
-			(*reqLogger).Info("Container " + foundContainer.Name + " wrong container security context")
+			(*reqLogger).Info(containerErrorMessageStart + foundContainer.Name + " wrong container security context")
 		} else if (foundContainer.Resources.Limits == nil) || (foundContainer.Resources.Requests == nil) {
-			(*reqLogger).Info("Container " + foundContainer.Name + " wrong container Resources")
+			(*reqLogger).Info(containerErrorMessageStart + foundContainer.Name + " wrong container Resources")
 		} else if !(foundContainer.Resources.Limits.Cpu().Equal(*expectedContainer.Resources.Limits.Cpu()) &&
 			foundContainer.Resources.Limits.Memory().Equal(*expectedContainer.Resources.Limits.Memory())) {
-			(*reqLogger).Info("Container " + foundContainer.Name + " wrong container Resources Limits")
+			(*reqLogger).Info(containerErrorMessageStart + foundContainer.Name + " wrong container Resources Limits")
 		} else if !(foundContainer.Resources.Requests.Cpu().Equal(*expectedContainer.Resources.Requests.Cpu()) &&
 			foundContainer.Resources.Requests.Memory().Equal(*expectedContainer.Resources.Requests.Memory())) {
-			(*reqLogger).Info("Container " + foundContainer.Name + " wrong container Resources Requests")
+			(*reqLogger).Info(containerErrorMessageStart + foundContainer.Name + " wrong container Resources Requests")
 		} else if !equalProbes(foundContainer.ReadinessProbe, expectedContainer.ReadinessProbe) {
-			(*reqLogger).Info("Container " + foundContainer.Name + " wrong container Readiness Probe")
+			(*reqLogger).Info(containerErrorMessageStart + foundContainer.Name + " wrong container Readiness Probe")
 		} else if !equalProbes(foundContainer.LivenessProbe, expectedContainer.LivenessProbe) {
-			(*reqLogger).Info("Container " + foundContainer.Name + " wrong container Liveness Probe")
+			(*reqLogger).Info(containerErrorMessageStart + foundContainer.Name + " wrong container Liveness Probe")
 		} else {
 			potentialDifference = false
 		}

--- a/controllers/resources/helper.go
+++ b/controllers/resources/helper.go
@@ -46,8 +46,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	odlm "github.com/IBM/operand-deployment-lifecycle-manager/api/v1alpha1"
-
-	v1alpha1 "github.com/IBM/ibm-licensing-operator/api/v1alpha1"
 )
 
 // cannot set to const due to k8s struct needing pointers to primitive types
@@ -159,7 +157,7 @@ func GetSecretToken(name string, namespace string, secretKey string, metaLabels 
 	return expectedSecret, nil
 }
 
-func AnnotateForService(httpCertSource v1alpha1.HTTPSCertsSource, isHTTPS bool, certName string) map[string]string {
+func AnnotateForService(isHTTPS bool, certName string) map[string]string {
 	if IsServiceCAAPI && isHTTPS {
 		return map[string]string{ocpCertSecretNameTag: certName}
 	}

--- a/controllers/resources/service/helper.go
+++ b/controllers/resources/service/helper.go
@@ -88,7 +88,7 @@ func GetServiceURL(instance *operatorv1alpha1.IBMLicensing) string {
 /*
 MergeWithSpecLabels attaches spec labels to the provided map of predefined labels.
 
-Helps cover some cases and optimise code (so that reconcile functions' `maybeAttachSpecLabels` only do the minimal
+Helps cover some cases and optimize code (so that reconcile functions' `maybeAttachSpecLabels` only do the minimal
 check) by pre-attaching the labels wherever `LabelsFor<Type>` functions are used (generally on resource creation).
 
 In the future, labels addition in reconciliation should be gone and only present in this helper module (or similar).

--- a/controllers/resources/service/secrets.go
+++ b/controllers/resources/service/secrets.go
@@ -64,6 +64,10 @@ func GetAPISecretToken(instance *operatorv1alpha1.IBMLicensing) (*corev1.Secret,
 	return resources.GetSecretToken(instance.Spec.APISecretToken, instance.Spec.InstanceNamespace, APISecretTokenKeyName, LabelsForMeta(instance))
 }
 
+func GetPrometheusCertSecret(instance *operatorv1alpha1.IBMLicensing) (*corev1.Secret, error) {
+	return resources.GetSecretToken(PrometheusServiceOCPCertName, instance.Spec.InstanceNamespace, PrometheusServiceOCPCertName, LabelsForMeta(instance))
+}
+
 func GetUploadToken(instance *operatorv1alpha1.IBMLicensing) (*corev1.Secret, error) {
 	return resources.GetSecretToken(APIUploadTokenName, instance.Spec.InstanceNamespace, APIUploadTokenKeyName, LabelsForMeta(instance))
 }

--- a/controllers/resources/service/service_monitor.go
+++ b/controllers/resources/service/service_monitor.go
@@ -49,11 +49,11 @@ func GetServiceMonitor(instance *operatorv1alpha1.IBMLicensing, name string, int
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: instance.Spec.InstanceNamespace,
-			Labels:    LabelsForServiceMonitor(),
+			Labels:    LabelsForServiceMonitor(instance),
 		},
 		Spec: monitoringv1.ServiceMonitorSpec{
 			Selector: metav1.LabelSelector{
-				MatchLabels: getPrometheusLabels(),
+				MatchLabels: getPrometheusLabels(instance),
 			},
 			Endpoints: []monitoringv1.Endpoint{
 				{

--- a/controllers/resources/service/services.go
+++ b/controllers/resources/service/services.go
@@ -69,7 +69,7 @@ func GetLicensingService(instance *operatorv1alpha1.IBMLicensing) *corev1.Servic
 			Name:        GetLicensingServiceName(instance),
 			Namespace:   instance.Spec.InstanceNamespace,
 			Labels:      metaLabels,
-			Annotations: resources.AnnotateForService(instance.Spec.HTTPSCertsSource, instance.Spec.HTTPSEnable, LicenseServiceInternalCertName),
+			Annotations: resources.AnnotateForService(instance.Spec.HTTPSEnable, LicenseServiceInternalCertName),
 		},
 		Spec: corev1.ServiceSpec{
 			Type: corev1.ServiceTypeClusterIP,
@@ -100,7 +100,7 @@ func GetPrometheusService(instance *operatorv1alpha1.IBMLicensing) *corev1.Servi
 			Name:        GetPrometheusServiceName(),
 			Namespace:   instance.Spec.InstanceNamespace,
 			Labels:      getPrometheusLabels(instance),
-			Annotations: resources.AnnotateForService(instance.Spec.HTTPSCertsSource, instance.Spec.HTTPSEnable, PrometheusServiceOCPCertName),
+			Annotations: resources.AnnotateForService(instance.Spec.HTTPSEnable, PrometheusServiceOCPCertName),
 		},
 		Spec: corev1.ServiceSpec{
 			Type: corev1.ServiceTypeClusterIP,

--- a/controllers/resources/service/services.go
+++ b/controllers/resources/service/services.go
@@ -99,7 +99,7 @@ func GetPrometheusService(instance *operatorv1alpha1.IBMLicensing) *corev1.Servi
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        GetPrometheusServiceName(),
 			Namespace:   instance.Spec.InstanceNamespace,
-			Labels:      getPrometheusLabels(),
+			Labels:      getPrometheusLabels(instance),
 			Annotations: resources.AnnotateForService(instance.Spec.HTTPSCertsSource, instance.Spec.HTTPSEnable, PrometheusServiceOCPCertName),
 		},
 		Spec: corev1.ServiceSpec{
@@ -122,7 +122,7 @@ func GetUsageService(instance *operatorv1alpha1.IBMLicensing) *corev1.Service {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      GetUsageServiceName(),
 			Namespace: instance.Spec.InstanceNamespace,
-			Labels:    getUsageServiceLabels(),
+			Labels:    getUsageServiceLabels(instance),
 		},
 		Spec: corev1.ServiceSpec{
 			Type: corev1.ServiceTypeClusterIP,
@@ -139,14 +139,10 @@ func GetUsageService(instance *operatorv1alpha1.IBMLicensing) *corev1.Service {
 	}
 }
 
-func getPrometheusLabels() map[string]string {
-	labels := make(map[string]string)
-	labels["release"] = ReleaseLabel
-	return labels
+func getPrometheusLabels(instance *operatorv1alpha1.IBMLicensing) map[string]string {
+	return MergeWithSpecLabels(instance, map[string]string{"release": ReleaseLabel})
 }
 
-func getUsageServiceLabels() map[string]string {
-	labels := make(map[string]string)
-	labels["release"] = ReleaseUsageLabel
-	return labels
+func getUsageServiceLabels(instance *operatorv1alpha1.IBMLicensing) map[string]string {
+	return MergeWithSpecLabels(instance, map[string]string{"release": ReleaseUsageLabel})
 }


### PR DESCRIPTION
Code tested on a default IBMLicensing operand provisioning. No extra params or testing was done yet (e.g. no testing with ingress enabled). To my knowledge, all resources owned by the operand should be affected when applying `spec.labels`.

Functionalities provide an easy extension for adding `spec.annotations`.