### PR TITLE
Update ibm-licensing-operator.clusterserviceversion.yaml

### DIFF
--- a/bundle/manifests/ibm-licensing-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-licensing-operator.clusterserviceversion.yaml
@@ -27,7 +27,7 @@ metadata:
     categories: Monitoring
     certified: "false"
     containerImage: icr.io/cpopen/ibm-licensing-operator:4.2.1
-    createdAt: "2023-10-27T10:09:06Z"
+    createdAt: "2023-11-15T13:05:11Z"
     description: The IBM Licensing Operator provides a Kubernetes CRD-Based API to monitor the license usage of products.
     nss.operator.ibm.com/managed-operators: ibm-licensing-operator-app
     olm.skipRange: '>=1.0.0 <4.2.1'
@@ -50,7 +50,7 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-      - description: 'IBMLicensing custom resource is used to create an instance of the License Service, used to collect information about license usage of IBM containerized products and IBM Cloud Paks per cluster. You can retrieve license usage data through a dedicated API call and generate an audit snapshot on demand. Documentation: For additional details regarding install parameters check: https://ibm.biz/icpfs39install. License: Please refer to the IBM Terms website (ibm.biz/lsvc-lic) to find the license terms for the particular IBM product for which you are deploying this component.'
+      - description: 'IBMLicensing custom resource is used to create an instance of the License Service, used to collect information about license usage of IBM containerized products and IBM Cloud Paks per cluster. You can retrieve license usage data through a dedicated API call and generate an audit snapshot on demand. Documentation: For additional details regarding install parameters check: https://ibm.biz/cpfs_4-3_install. License: Please refer to the IBM Terms website (ibm.biz/lsvc-lic) to find the license terms for the particular IBM product for which you are deploying this component.'
         displayName: IBM License Service
         kind: IBMLicensing
         name: ibmlicensings.operator.ibm.com
@@ -228,7 +228,7 @@ spec:
       - kind: IBMLicensingDefinition
         name: ibmlicensingdefinitions.operator.ibm.com
         version: v1
-      - description: 'IBMLicensingMetadata is the schema for IBM License Service. Thanks to IBMLicensingMetadata, you can track the license usage of Virtual Processor Core (VPC) metric by Pods that are managed by automation, for which licensing annotations are not defined at the time of deployment, such as the open source OpenLiberty. / For more information, see documentation: https://ibm.biz/icpfs39install. By installing the operator for IBM License Service, you accept the license terms: https://ibm.biz/icpfs39license.'
+      - description: 'IBMLicensingMetadata is the schema for IBM License Service. Thanks to IBMLicensingMetadata, you can track the license usage of Virtual Processor Core (VPC) metric by Pods that are managed by automation, for which licensing annotations are not defined at the time of deployment, such as the open source OpenLiberty. / For more information, see documentation: https://ibm.biz/cpfs_4-3_install. By installing the operator for IBM License Service, you accept the license terms: https://ibm.biz/icpfs39license.'
         displayName: IBMLicensing Metadata
         kind: IBMLicensingMetadata
         name: ibmlicensingmetadatas.operator.ibm.com
@@ -238,7 +238,7 @@ spec:
         version: v1
   description: |-
     **Important:**
-    - If you are using the IBM Licensing Operator as part of an IBM Cloud Pak, see the documentation for that IBM Cloud Pak to learn more about how to install and use the operator service. For the link to your IBM Cloud Pak documentation, see [IBM Cloud Paks that use Common Services](https://ibm.biz/BdyGwb).
+    - If you are using the IBM Licensing Operator as part of an IBM Cloud Pak, see the documentation for that IBM Cloud Pak to learn more about how to install and use the operator service. For the link to your IBM Cloud Pak documentation, see [IBM Cloud Paks that use Common Services](https://ibm.biz/cpfs_welcome).
     - If you are using a stand-alone IBM Container Software, you can use the IBM Licensing Operator directly. For more information, see [ibm-licensing-operator for stand-alone IBM Containerized Software](https://ibm.biz/BdyGwh).
 
     **IBM Licensing Operator overview**

--- a/config/manifests/bases/ibm-licensing-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-licensing-operator.clusterserviceversion.yaml
@@ -37,9 +37,9 @@ spec:
         containerized products and IBM Cloud Paks per cluster. You can retrieve license
         usage data through a dedicated API call and generate an audit snapshot on
         demand. Documentation: For additional details regarding install parameters
-        check: https://ibm.biz/cpfs_4-3_install. License: Please refer to the IBM Terms
-        website (ibm.biz/lsvc-lic) to find the license terms for the particular IBM
-        product for which you are deploying this component.'
+        check: https://ibm.biz/cpfs_4-3_install. License: Please refer to the IBM
+        Terms website (ibm.biz/lsvc-lic) to find the license terms for the particular
+        IBM product for which you are deploying this component.'
       displayName: IBM License Service
       kind: IBMLicensing
       name: ibmlicensings.operator.ibm.com

--- a/config/manifests/bases/ibm-licensing-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-licensing-operator.clusterserviceversion.yaml
@@ -37,7 +37,7 @@ spec:
         containerized products and IBM Cloud Paks per cluster. You can retrieve license
         usage data through a dedicated API call and generate an audit snapshot on
         demand. Documentation: For additional details regarding install parameters
-        check: https://ibm.biz/icpfs39install. License: Please refer to the IBM Terms
+        check: https://ibm.biz/cpfs_4-3_install. License: Please refer to the IBM Terms
         website (ibm.biz/lsvc-lic) to find the license terms for the particular IBM
         product for which you are deploying this component.'
       displayName: IBM License Service
@@ -231,7 +231,7 @@ spec:
         to IBMLicensingMetadata, you can track the license usage of Virtual Processor
         Core (VPC) metric by Pods that are managed by automation, for which licensing
         annotations are not defined at the time of deployment, such as the open source
-        OpenLiberty. / For more information, see documentation: https://ibm.biz/icpfs39install.
+        OpenLiberty. / For more information, see documentation: https://ibm.biz/cpfs_4-3_install.
         By installing the operator for IBM License Service, you accept the license
         terms: https://ibm.biz/icpfs39license.'
       displayName: IBMLicensing Metadata
@@ -240,7 +240,7 @@ spec:
       version: v1alpha1
   description: |-
     **Important:**
-    - If you are using the IBM Licensing Operator as part of an IBM Cloud Pak, see the documentation for that IBM Cloud Pak to learn more about how to install and use the operator service. For the link to your IBM Cloud Pak documentation, see [IBM Cloud Paks that use Common Services](https://ibm.biz/BdyGwb).
+    - If you are using the IBM Licensing Operator as part of an IBM Cloud Pak, see the documentation for that IBM Cloud Pak to learn more about how to install and use the operator service. For the link to your IBM Cloud Pak documentation, see [IBM Cloud Paks that use Common Services](https://ibm.biz/cpfs_welcome).
     - If you are using a stand-alone IBM Container Software, you can use the IBM Licensing Operator directly. For more information, see [ibm-licensing-operator for stand-alone IBM Containerized Software](https://ibm.biz/BdyGwh).
 
     **IBM Licensing Operator overview**


### PR DESCRIPTION
Updated csv files to fix the dead links. 

Existing link - Updated link

[https://ibm.biz/icpfs39install](https://ibm.biz/icpfs39install) - [https://ibm.biz/cpfs_4-3_install](https://ibm.biz/cpfs_4-3_install)

[https://ibm.biz/cpcs_cloudpaks](https://ibm.biz/cpcs_cloudpaks) - [https://www.ibm.com/docs/en/cloud-paks](https://www.ibm.com/docs/en/cloud-paks)

[https://ibm.biz/cpcs_opinstall](https://ibm.biz/cpcs_opinstall) - [https://ibm.biz/cpfs_4-3_install](https://ibm.biz/cpfs_4-3_install)

[https://ibm.biz/cpcs_opdependencies](https://ibm.biz/cpcs_opdependencies) - [https://ibm.biz/cpfs_4-3_dependencies](https://ibm.biz/cpfs_4-3_dependencies)

[https://ibm.biz/cpcs_opinstprereq](https://ibm.biz/cpcs_opinstprereq) - [https://ibm.biz/cpfs_4-3_prep](https://ibm.biz/cpfs_4-3_prep)

