### PR TITLE
Add USER instruction to the dockerfiles to enhance security

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -19,3 +19,5 @@ LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 COPY bundle/manifests /manifests/
 COPY bundle/metadata /metadata/
 COPY bundle/tests/scorecard /tests/scorecard/
+
+USER 1001

--- a/common/scripts/catalog/Dockerfile
+++ b/common/scripts/catalog/Dockerfile
@@ -29,6 +29,8 @@ RUN cp /build/bin/opm /bin/opm \
     && cp /build/bin/configmap-server /bin/configmap-server \
     && cp /build/bin/registry-server /bin/registry-server
 
+USER 1001
+
 FROM alpine AS builder
 
 COPY manifests manifests
@@ -36,6 +38,7 @@ COPY --from=operator-registry /bin/initializer /bin/initializer
 
 RUN /bin/initializer -o ./bundles.db
 
+USER 1001
 
 FROM scratch
 
@@ -61,3 +64,5 @@ COPY --from=operator-registry /bin/registry-server /bin/grpc_health_probe /bin/
 EXPOSE 50051
 ENTRYPOINT ["/bin/registry-server"]
 CMD ["--database", "/bundles.db"]
+
+USER 1001

--- a/common/scripts/catalog_build.sh
+++ b/common/scripts/catalog_build.sh
@@ -42,7 +42,7 @@ VCS_URL=https://github.com/IBM/ibm-common-service-catalog
 VCS_REF=random
 
 echo "Building and pushing catalog"
-docker build -t "$CATALOG_NAME":"$MANIFEST_VERSION" --build-arg \ VCS_REF=${VCS_REF} --build-arg VCS_URL=${VCS_URL} -f Dockerfile .
+docker build -t "$CATALOG_NAME":"$MANIFEST_VERSION" --build-arg \ VCS_REF=${VCS_REF} --build-arg VCS_URL=${VCS_URL} --security-opt=no-new-privileges -f Dockerfile .
 docker push "$CATALOG_NAME":"$MANIFEST_VERSION"
 docker tag "$CATALOG_NAME":"$MANIFEST_VERSION" "$CATALOG_NAME":latest
 docker push "$CATALOG_NAME":latest


### PR DESCRIPTION
When executing a Docker image, by default the user that runs the process is root. As a best practice, you should run with a user that does not have high privileges; this help prevent privilege escalation. Apple the Principle of Least Privilege (POLP) when building or running a Docker image: give your user only the privileges it needs to perform the intended functions.

By default, Docker runs containers with a root user, which can create a security risk and cause permission issues when accessing files and directories. Hence, the container user should be a non-root user with appropriate permissions.



Just as in classic VM deployments, processes should not be run with root permissions. Instead, the image should contain a non-root user that runs the application.

In a Dockerfile, you can achieve this by adding another layer that adds a (system) user and group and setting it as the current user (instead of the default, root):