### PR TITLE
[LTSR] Reconcile on imagePullSecrets change in IBMLicensing CR

### DIFF
--- a/controllers/resources/deployments.go
+++ b/controllers/resources/deployments.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 )
 
 func equalProbes(probe1 *corev1.Probe, probe2 *corev1.Probe) bool {
@@ -143,7 +144,7 @@ func equalImagePullSecrets(imagePullSecrets1, imagePullSecrets2 []corev1.LocalOb
 		return imagePullSecrets2Copy[i].Name < imagePullSecrets2Copy[j].Name
 	})
 
-	return reflect.DeepEqual(imagePullSecrets1Copy, imagePullSecrets2Copy)
+	return equality.Semantic.DeepEqual(imagePullSecrets1Copy, imagePullSecrets2Copy)
 }
 
 func ShouldUpdateDeployment(

--- a/controllers/resources/deployments.go
+++ b/controllers/resources/deployments.go
@@ -133,15 +133,17 @@ func equalImagePullSecrets(imagePullSecrets1, imagePullSecrets2 []corev1.LocalOb
 	if len(imagePullSecrets1) != len(imagePullSecrets2) {
 		return false
 	}
+	imagePullSecrets1Copy := append([]corev1.LocalObjectReference{}, imagePullSecrets1...)
+	imagePullSecrets2Copy := append([]corev1.LocalObjectReference{}, imagePullSecrets2...)
 
-	sort.Slice(imagePullSecrets1, func(i, j int) bool {
-		return imagePullSecrets1[i].Name < imagePullSecrets1[j].Name
+	sort.Slice(imagePullSecrets1Copy, func(i, j int) bool {
+		return imagePullSecrets1Copy[i].Name < imagePullSecrets1Copy[j].Name
 	})
-	sort.Slice(imagePullSecrets2, func(i, j int) bool {
-		return imagePullSecrets2[i].Name < imagePullSecrets2[j].Name
+	sort.Slice(imagePullSecrets2Copy, func(i, j int) bool {
+		return imagePullSecrets2Copy[i].Name < imagePullSecrets2Copy[j].Name
 	})
 
-	return reflect.DeepEqual(imagePullSecrets1, imagePullSecrets2)
+	return reflect.DeepEqual(imagePullSecrets1Copy, imagePullSecrets2Copy)
 }
 
 func ShouldUpdateDeployment(

--- a/controllers/resources/deployments.go
+++ b/controllers/resources/deployments.go
@@ -18,6 +18,7 @@ package resources
 
 import (
 	"reflect"
+	"sort"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -128,6 +129,21 @@ func equalContainerLists(reqLogger *logr.Logger, containers1 []corev1.Container,
 	return !potentialDifference
 }
 
+func equalImagePullSecrets(imagePullSecrets1, imagePullSecrets2 []corev1.LocalObjectReference) bool {
+	if len(imagePullSecrets1) != len(imagePullSecrets2) {
+		return false
+	}
+
+	sort.Slice(imagePullSecrets1, func(i, j int) bool {
+		return imagePullSecrets1[i].Name < imagePullSecrets1[j].Name
+	})
+	sort.Slice(imagePullSecrets2, func(i, j int) bool {
+		return imagePullSecrets2[i].Name < imagePullSecrets2[j].Name
+	})
+
+	return reflect.DeepEqual(imagePullSecrets1, imagePullSecrets2)
+}
+
 func ShouldUpdateDeployment(
 	reqLogger *logr.Logger,
 	expectedSpec *corev1.PodTemplateSpec,
@@ -152,6 +168,8 @@ func ShouldUpdateDeployment(
 		(*reqLogger).Info("Deployment wrong containers")
 	} else if !equalContainerLists(reqLogger, foundSpec.Spec.InitContainers, expectedSpec.Spec.InitContainers) {
 		(*reqLogger).Info("Deployment wrong init containers")
+	} else if !equalImagePullSecrets(foundSpec.Spec.ImagePullSecrets, expectedSpec.Spec.ImagePullSecrets) {
+		(*reqLogger).Info("Deployment wrong image pull secrets")
 	} else {
 		// check if if all expected labels exists in found labels
 		expectedLabels := expectedSpec.GetLabels()

--- a/controllers/resources/service/deployments.go
+++ b/controllers/resources/service/deployments.go
@@ -32,8 +32,9 @@ func GetLicensingDeployment(instance *operatorv1alpha1.IBMLicensing) *appsv1.Dep
 	selectorLabels := LabelsForSelector(instance)
 	podLabels := LabelsForLicensingPod(instance)
 
-	imagePullSecrets := []corev1.LocalObjectReference{}
+	var imagePullSecrets []corev1.LocalObjectReference
 	if instance.Spec.ImagePullSecrets != nil {
+		imagePullSecrets = []corev1.LocalObjectReference{}
 		for _, pullSecret := range instance.Spec.ImagePullSecrets {
 			imagePullSecrets = append(imagePullSecrets, corev1.LocalObjectReference{Name: pullSecret})
 		}


### PR DESCRIPTION
**Context**
Currently it is possible to pass `imagePullSecrets` for the LS deployment to the CR, however the deployment will not be reconciled on this change. The values will only be applied during the deployment recreation.

**Solution**
Detect `imagePullSecrets` changes in the CR and reconcile LS deployment.

**Expected behaviour**
- if `imagePullSecrets` is **not** provided in the CR, then in the LS pod the field will be empty or it will be populated automatically with `imagePullSecrets` from `ServiceAccount` (if present)
- if `imagePullSecrets`  provided in the CR, then in the LS pod, this value will be used, overriding possible `imagePullSecrets` set by `ServiceAccount` (if present)

Issue: 62826