### PR TITLE
change name of artifact

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -145,7 +145,7 @@ jobs:
       uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: operator results
+        name: operator results ${{matrix.k8s}}
         path: ./*.txt
 
 


### PR DESCRIPTION
## Description
One of our action (upload-artifact@v2) was deprecated and failed automatically. Previously I introduced upload-artifact@v4 to fix builds however it has breaking changes - e.g. you can't upload artifacts with same name (as we do). Now I add K8s version to name so they have different names.

## Parent issue
[My kindness <3 <3 ](https://jsw.ibm.com/browse/ILS-132)

## Type
What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which modifies existing functionality)
- [ ] Dependency/version upgrade/CVE remediation
- [x] Velocity-improvement (enhancing testing strategy, tidy code, CICD update)

## Extra information
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Lint and unit tests pass locally with my changes
- [ ] Tester is needed
- [ ] This change requires a documentation update - create separate issue with input for *doc* team

## Testing
- [ ] Manual tests
- [ ] Automated sert tests: <jenkins sert logs url>

## Test images for further QA testing (if applicable):
-
-
