### PR TITLE
ILS-233 LS operator keeps restarting when there is OperandRequest in non-existent namespace

### DIFF
--- a/controllers/operandrequest_discovery.go
+++ b/controllers/operandrequest_discovery.go
@@ -106,7 +106,7 @@ func DiscoverOperandRequests(logger *logr.Logger, writer c.Writer, reader c.Read
 }
 
 // This check is added because of the edge case scenario which is described in: https://jsw.ibm.com/browse/ILS-233
-// It can happen that there is an OperandRequest in a non-existent namespace, which causes LS operator to restart constantly
+// It can happen that there is an OperandRequest in a non-existent namespace, which causes LS operator to restart constantly. Such scenario was found when namespace was force deleted, while OperandRequest had pending finalization due to removed Pod providing finalization logic
 // To prevent such case, we are additionally checking if the namespace actually exists when processing OperandRequests
 func checkIfOperandRequestNamespaceIsValid(logger *logr.Logger, reader c.Reader, operandRequest odlm.OperandRequest) bool {
 	if namespaceExists, err := namespaceExists(reader, operandRequest.Namespace); err != nil {

--- a/controllers/operandrequest_discovery.go
+++ b/controllers/operandrequest_discovery.go
@@ -74,7 +74,7 @@ func DiscoverOperandRequests(logger *logr.Logger, writer c.Writer, reader c.Read
 
 		namespaceListToExtend = []string{}
 		for _, operandRequest := range operandRequestList.Items {
-			if checkIfOperandRequestNamespaceIsValid(logger, reader, operandRequest) {
+			if !checkIfOperandRequestNamespaceIsValid(logger, reader, operandRequest) {
 				continue
 			}
 			if hasBinding := res.HasOperandRequestBindingForLicensing(operandRequest); hasBinding {


### PR DESCRIPTION
**Split from issue**: https://github.ibm.com/PrivateCloud-analytics/CPD-Quality/issues/30974
**JIRA**: https://jsw.ibm.com/browse/ILS-233

**Bug:**
The LS operator keeps adding and removing namespace from OperatorGroup, which causes it to restart constantly.

**Why it happens:**
The issue persists because there is an OperandRequest in a non-existent namespace. Our OperandRequestController detects the OperandRequest and add its namespace to the OperatorGroup. We also have an async job which periodically runs and checks whether namespaces inside OperatorGroup exist (introduced here: https://github.com/IBM/ibm-licensing-operator/pull/932). The namespace is not present in the cluster, so we delete it from OperatorGroup, which triggers LS operator restart. The reason why there is an OperandRequest in a non-existent namespace is probably due to some finalisers issue and namespace force deletion, please see this comment: https://github.ibm.com/PrivateCloud-analytics/CPD-Quality/issues/30974#issuecomment-95765457.
```
➜ oc get namespace rk-instance -o yaml
Error from server (NotFound): namespaces "rk-instance" not found

➜ oc get operandrequest --all-namespaces
NAMESPACE       NAME                                AGE     PHASE     CREATED AT
...
rk-instance     catalog-api-ibm-licensing-request   28d     Running   2024-10-01T14:54:27Z
rk-instance     ibm-iam-request                     29d     Running   2024-10-01T13:35:10Z
rk-instance     postgresql-operator-request         29d     Running   2024-10-01T13:36:56Z
rk-instance     zen-ca-operand-request              29d     Pending   2024-10-01T13:40:38Z
... 
```

**Solution**:
The possible solution is to add an extra check to OperandRequestController to verify whether the namespace exists before adding it to OperatorGroup. In general this check is not needed, it's only to prevent from such strange edge cases.