### PR TITLE
ILS-306 Update check-tool runner to node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ on:
     
 env:
   GO_VERSION: "1.22"
-  GOLANGCI_LINT_VERSION: 1.56.1
+  GOLANGCI_LINT_VERSION: 1.62.2
 
 jobs:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,10 @@ jobs:
           fetch-depth: 1  # Fetch only the latest commit
 
       - name: Install golangci-lint v${{ env.GOLANGCI_LINT_VERSION }}
-        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin v${{ env.GOLANGCI_LINT_VERSION }}
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v${{ env.GOLANGCI_LINT_VERSION }}
+          working-directory: ./ibm-licensing-operator
 
       - name: Check
         run: make check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,11 +62,6 @@ jobs:
         with:
           fetch-depth: 1  # Fetch only the latest commit
 
-      - uses: actions/setup-go@v4
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache: false
-
       - name: Install golangci-lint v${{ env.GOLANGCI_LINT_VERSION }}
         run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin v${{ env.GOLANGCI_LINT_VERSION }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,6 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: v${{ env.GOLANGCI_LINT_VERSION }}
-          working-directory: ./ibm-licensing-operator
 
       - name: Check
         run: make check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
   check:
     name: Check
     runs-on: ubuntu-22.04
-    # this image runs on the ubuntu 18.04 - blocker for using newer versions of dependencies
+    # This image moves up to ubuntu focal and node 20.18.0.
     container: 
       image: quay.io/cicdtest/check-tool:v20241203-df2ce26d0
     steps:
@@ -58,9 +58,14 @@ jobs:
 
       # it must be v3 to avoid fetching dependencies using newer version of GLIBC
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1  # Fetch only the latest commit
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: false
 
       - name: Install golangci-lint v${{ env.GOLANGCI_LINT_VERSION }}
         run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin v${{ env.GOLANGCI_LINT_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,12 +63,13 @@ jobs:
           fetch-depth: 1  # Fetch only the latest commit
 
       - name: Install golangci-lint v${{ env.GOLANGCI_LINT_VERSION }}
-        uses: golangci/golangci-lint-action@v3
-        with:
-          version: v${{ env.GOLANGCI_LINT_VERSION }}
+        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin v${{ env.GOLANGCI_LINT_VERSION }}
 
+      # add flag to get rid of the version control warning
       - name: Check
-        run: make check
+        run: |
+          go env -w GOFLAGS=-buildvcs=false
+          make check
           
   build:
     needs: detect-docs-only-changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-22.04
     # this image runs on the ubuntu 18.04 - blocker for using newer versions of dependencies
     container: 
-      image: quay.io/cicdtest/check-tool:v20240711-d1227e929
+      image: quay.io/cicdtest/check-tool:v20241203-df2ce26d0
     steps:
       - name: Check Node.js and GLIBC versions
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,8 @@ on:
   workflow_dispatch:
     
 env:
-  GO_VERSION: "1.21"
+  GO_VERSION: "1.22"
   GOLANGCI_LINT_VERSION: 1.56.1
-  # https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
-  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 jobs:
 

--- a/common/config/.golangci.yml
+++ b/common/config/.golangci.yml
@@ -5,7 +5,7 @@ run:
   # Exclude test files from analysis
   tests: false
 
-  go: "1.20"
+  go: "1.22"
 
 linters:
   # please, do not use `enable-all`: it's deprecated and will be removed soon.

--- a/controllers/ibmlicensing_controller.go
+++ b/controllers/ibmlicensing_controller.go
@@ -262,7 +262,7 @@ func (r *IBMLicensingReconciler) Reconcile(_ context.Context, req reconcile.Requ
 }
 
 func (r *IBMLicensingReconciler) findAndMarkActiveIBMLicensing(ibmlicensingList *operatorv1alpha1.IBMLicensingList) error {
-	if ibmlicensingList.Items == nil || len(ibmlicensingList.Items) == 0 {
+	if len(ibmlicensingList.Items) == 0 {
 		return nil
 	}
 


### PR DESCRIPTION
Added flag -buildvcs=false that disables version control information embedding during the build process and unblocks the golangci lint error:
```log
 VCS status: exit status 128
```

Setting -buildvcs=false tells the Go tool to skip embedding any version control information in the binary.
This allows to run linter in a clean or isolated environment without access to the version control system.

Docs:
```
        -buildvcs
                Whether to stamp binaries with version control information. By default,
                version control information is stamped into a binary if the main package
                and the main module containing it are in the repository containing the
                current directory (if there is a repository). Use -buildvcs=false to
                omit version control information.
```

More info: https://go.dev/doc/go1.18#go-version