### PR TITLE
ILS-2025 Remove minKube version requirement

### DIFF
--- a/bundle/manifests/ibm-licensing-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-licensing-operator.clusterserviceversion.yaml
@@ -81,7 +81,7 @@ metadata:
     categories: Monitoring
     certified: "false"
     containerImage: icr.io/cpopen/ibm-licensing-operator:4.2.21
-    createdAt: "2026-03-30T16:26:37Z"
+    createdAt: "2026-04-01T13:24:59Z"
     description: The IBM Licensing Operator provides a Kubernetes CRD-Based API to monitor the license usage of products.
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
@@ -880,7 +880,6 @@ spec:
     - email: talk2sam@us.ibm.com
       name: talk2sam
   maturity: alpha
-  minKubeVersion: 1.26.0
   provider:
     name: IBM
   version: 4.2.21

--- a/config/manifests/bases/ibm-licensing-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-licensing-operator.clusterserviceversion.yaml
@@ -415,7 +415,6 @@ spec:
   - email: talk2sam@us.ibm.com
     name: talk2sam
   maturity: alpha
-  minKubeVersion: 1.26.0
   provider:
     name: IBM
   relatedImages:


### PR DESCRIPTION
## Description
Remove minKube version requirement. minKubeVersion was added because of gatewayAPI integration - support for gateways can be sacrificed for very old kubernetes versions. Upgrades on old kubernetes versions will not be stopped but gatewayAPI integration will have to be manually disabled in LS CR.

Previous state was restored - no minKubernetes version requirement set

## Parent issue
ILS-2025
