### PR TITLE
ILS-2074 Cache gateway resources only in operator namespace

### DIFF
--- a/main.go
+++ b/main.go
@@ -162,6 +162,7 @@ func main() {
 	}
 	if err := res.UpdateCacheClusterExtensions(probeClient, setupLog); err != nil {
 		setupLog.Error(err, "Error during checking K8s API")
+		os.Exit(1)
 	}
 	if res.IsGatewayAPI {
 		byObject[&gatewayv1.Gateway{}] = cache.ByObject{Namespaces: operatorNamespaceOnly}

--- a/main.go
+++ b/main.go
@@ -148,7 +148,30 @@ func main() {
 	// in its own namespace and should only be cached there
 	operatorNamespaceOnly := map[string]cache.Config{operatorNamespace: {}}
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	byObject := map[client.Object]cache.ByObject{
+		&corev1.Secret{}:     {Label: licensingLabelSelector},
+		&appsv1.Deployment{}: {Label: licensingLabelSelector},
+		&corev1.Pod{}:        {Label: licensingLabelSelector},
+	}
+
+	restConfig := ctrl.GetConfigOrDie()
+	probeClient, err := client.New(restConfig, client.Options{Scheme: scheme})
+	if err != nil {
+		setupLog.Error(err, "unable to create probe client for CRD discovery")
+		os.Exit(1)
+	}
+	if err := res.UpdateCacheClusterExtensions(probeClient, setupLog); err != nil {
+		setupLog.Error(err, "Error during checking K8s API")
+	}
+	if res.IsGatewayAPI {
+		byObject[&gatewayv1.Gateway{}] = cache.ByObject{Namespaces: operatorNamespaceOnly}
+		byObject[&gatewayv1.HTTPRoute{}] = cache.ByObject{Namespaces: operatorNamespaceOnly}
+	}
+	if res.IsBackendTLSPolicyAPI {
+		byObject[&gatewayv1.BackendTLSPolicy{}] = cache.ByObject{Namespaces: operatorNamespaceOnly}
+	}
+
+	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
 			BindAddress: metricsAddr,
@@ -158,14 +181,7 @@ func main() {
 		LeaderElectionID: "e1f51baf.ibm.com",
 		Cache: cache.Options{
 			DefaultNamespaces: defaultNamespaces,
-			ByObject: map[client.Object]cache.ByObject{
-				&corev1.Secret{}:              {Label: licensingLabelSelector},
-				&appsv1.Deployment{}:          {Label: licensingLabelSelector},
-				&corev1.Pod{}:                 {Label: licensingLabelSelector},
-				&gatewayv1.Gateway{}:          {Namespaces: operatorNamespaceOnly},
-				&gatewayv1.HTTPRoute{}:        {Namespaces: operatorNamespaceOnly},
-				&gatewayv1.BackendTLSPolicy{}: {Namespaces: operatorNamespaceOnly},
-			},
+			ByObject:          byObject,
 		},
 	})
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -144,6 +144,10 @@ func main() {
 		defaultNamespaces[ns] = cache.Config{}
 	}
 
+	// Gateway API resources (Gateway, HTTPRoute, BackendTLSPolicy) are only ever created by the operator
+	// in its own namespace and should only be cached there
+	operatorNamespaceOnly := map[string]cache.Config{operatorNamespace: {}}
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
@@ -155,9 +159,12 @@ func main() {
 		Cache: cache.Options{
 			DefaultNamespaces: defaultNamespaces,
 			ByObject: map[client.Object]cache.ByObject{
-				&corev1.Secret{}:     {Label: licensingLabelSelector},
-				&appsv1.Deployment{}: {Label: licensingLabelSelector},
-				&corev1.Pod{}:        {Label: licensingLabelSelector},
+				&corev1.Secret{}:              {Label: licensingLabelSelector},
+				&appsv1.Deployment{}:          {Label: licensingLabelSelector},
+				&corev1.Pod{}:                 {Label: licensingLabelSelector},
+				&gatewayv1.Gateway{}:          {Namespaces: operatorNamespaceOnly},
+				&gatewayv1.HTTPRoute{}:        {Namespaces: operatorNamespaceOnly},
+				&gatewayv1.BackendTLSPolicy{}: {Namespaces: operatorNamespaceOnly},
 			},
 		},
 	})
@@ -211,10 +218,23 @@ func main() {
 		} else {
 			go controllers.DiscoverOperandRequests(&crdLogger, mgr.GetClient(), mgr.GetAPIReader(), watchNamespaces, nssEnabledSemaphore)
 
-			logger := ctrl.Log.WithName("operatorgroup-namespaces-watcher")
-			removeStaleNamespacesTaskCtx, cancelRemoveStaleNamespacesTask := context.WithCancel(context.Background())
-			go controllers.RunRemoveStaleNamespacesFromOperatorGroupTask(removeStaleNamespacesTaskCtx, &logger, mgr.GetClient(), mgr.GetAPIReader())
-			routinesToCancel = append(routinesToCancel, cancelRemoveStaleNamespacesTask)
+			// OperatorGroup belongs to OLM (operators.coreos.com/v1). On clusters without OLM installed, skip the stale-namespace cleanup task,
+			// otherwise every run produces a "no matches for kind OperatorGroup" error
+			operatorGroupList := operatorframeworkv1.OperatorGroupList{}
+			operatorGroupCRDExists, err := res.DoesCRDExist(mgr.GetAPIReader(), &operatorGroupList)
+			if err != nil {
+				setupLog.Error(err, "An error occurred while checking for OperatorGroup CRD existence. operatorgroup-namespaces-watcher will not be started")
+			}
+
+			if operatorGroupCRDExists {
+				logger := ctrl.Log.WithName("operatorgroup-namespaces-watcher")
+				removeStaleNamespacesTaskCtx, cancelRemoveStaleNamespacesTask := context.WithCancel(context.Background())
+
+				go controllers.RunRemoveStaleNamespacesFromOperatorGroupTask(removeStaleNamespacesTaskCtx, &logger, mgr.GetClient(), mgr.GetAPIReader())
+				routinesToCancel = append(routinesToCancel, cancelRemoveStaleNamespacesTask)
+			} else {
+				setupLog.Info("OperatorGroup CRD not found in cluster. operatorgroup-namespaces-watcher disabled")
+			}
 		}
 	} else {
 		logger := ctrl.Log.WithName("crd-watcher").WithName("OperandRequest")

--- a/main.go
+++ b/main.go
@@ -139,15 +139,6 @@ func main() {
 
 	licensingLabelSelector, _ := labels.Parse("release in (ibm-licensing-service)")
 
-	defaultNamespaces := make(map[string]cache.Config)
-	for _, ns := range watchNamespaces {
-		defaultNamespaces[ns] = cache.Config{}
-	}
-
-	// Gateway API resources (Gateway, HTTPRoute, BackendTLSPolicy) are only ever created by the operator
-	// in its own namespace and should only be cached there
-	operatorNamespaceOnly := map[string]cache.Config{operatorNamespace: {}}
-
 	byObject := map[client.Object]cache.ByObject{
 		&corev1.Secret{}:     {Label: licensingLabelSelector},
 		&appsv1.Deployment{}: {Label: licensingLabelSelector},
@@ -164,12 +155,22 @@ func main() {
 		setupLog.Error(err, "Error during checking K8s API")
 		os.Exit(1)
 	}
+
+	// Gateway API resources (Gateway, HTTPRoute, BackendTLSPolicy) are only ever created by the operator
+	// in its own namespace and should only be cached there
+	operatorNamespaceOnly := map[string]cache.Config{operatorNamespace: {}}
+
 	if res.IsGatewayAPI {
 		byObject[&gatewayv1.Gateway{}] = cache.ByObject{Namespaces: operatorNamespaceOnly}
 		byObject[&gatewayv1.HTTPRoute{}] = cache.ByObject{Namespaces: operatorNamespaceOnly}
 	}
 	if res.IsBackendTLSPolicyAPI {
 		byObject[&gatewayv1.BackendTLSPolicy{}] = cache.ByObject{Namespaces: operatorNamespaceOnly}
+	}
+
+	defaultNamespaces := make(map[string]cache.Config)
+	for _, ns := range watchNamespaces {
+		defaultNamespaces[ns] = cache.Config{}
 	}
 
 	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{


### PR DESCRIPTION
## Description
Bug fixes:
- Cache gateway resources only in operator namespace
- Additionally: skip stale ns cleanup if no operator group CRD-s exist (valid for no OLM installs)

## Parent issue
ILS-2074

## Type
What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which modifies existing functionality)
- [ ] Dependency/version upgrade/CVE remediation
- [ ] Velocity-improvement (enhancing testing strategy, tidy code, CICD update)

## Extra information
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [x] Lint and unit tests pass locally with my changes
- [x] Tester is needed
- [ ] This change requires a documentation update - create separate issue with input for *doc* team

## Testing
- [x] Manual tests
- [ ] Automated sert tests: <provide console log from succesful run here>
Before merging your PR, ensure Jenkins tests pass by following these steps:
1. Run the tests on the clustered environment (OCP/IKS depending on the content of the pull request) using Jenkins pipelines.
2. If the build fails due to being unstable, restart it.
3. If the failure is due to other issues unrelated to the tests themselves, address the underlying problem before proceeding.

## Test images for further QA testing (if applicable):
-
-
