### PR TITLE
ILS-2109 Run DiscoverOperandRequests only when Operator Group CRD-s extist

### DIFF
--- a/main.go
+++ b/main.go
@@ -234,7 +234,7 @@ func main() {
 		if isNssActive {
 			setupLog.Info("Namespace Scope ConfigMap detected. operandrequest-discovery disabled")
 		} else {
-			// On clusters without OLM installed, skip both boperandrequest-discovery and the stale-namespace cleanup task, 
+			// On clusters without OLM installed, skip both operandrequest-discovery and the stale-namespace cleanup task, 
 			// otherwise every run produces a "no matches for kind OperatorGroup" error
 			operatorGroupList := operatorframeworkv1.OperatorGroupList{}
 			operatorGroupCRDExists, err := res.DoesCRDExist(mgr.GetAPIReader(), &operatorGroupList)

--- a/main.go
+++ b/main.go
@@ -234,7 +234,7 @@ func main() {
 		if isNssActive {
 			setupLog.Info("Namespace Scope ConfigMap detected. operandrequest-discovery disabled")
 		} else {
-			// On clusters without OLM installed, skip bothboperandrequest-discovery and the stale-namespace cleanup task, 
+			// On clusters without OLM installed, skip both boperandrequest-discovery and the stale-namespace cleanup task, 
 			// otherwise every run produces a "no matches for kind OperatorGroup" error
 			operatorGroupList := operatorframeworkv1.OperatorGroupList{}
 			operatorGroupCRDExists, err := res.DoesCRDExist(mgr.GetAPIReader(), &operatorGroupList)

--- a/main.go
+++ b/main.go
@@ -234,24 +234,24 @@ func main() {
 		if isNssActive {
 			setupLog.Info("Namespace Scope ConfigMap detected. operandrequest-discovery disabled")
 		} else {
-			go controllers.DiscoverOperandRequests(&crdLogger, mgr.GetClient(), mgr.GetAPIReader(), watchNamespaces, nssEnabledSemaphore)
-
-			// OperatorGroup belongs to OLM (operators.coreos.com/v1). On clusters without OLM installed, skip the stale-namespace cleanup task,
+			// On clusters without OLM installed, skip bothboperandrequest-discovery and the stale-namespace cleanup task, 
 			// otherwise every run produces a "no matches for kind OperatorGroup" error
 			operatorGroupList := operatorframeworkv1.OperatorGroupList{}
 			operatorGroupCRDExists, err := res.DoesCRDExist(mgr.GetAPIReader(), &operatorGroupList)
 			if err != nil {
-				setupLog.Error(err, "An error occurred while checking for OperatorGroup CRD existence. operatorgroup-namespaces-watcher will not be started")
+				setupLog.Error(err, "An error occurred while checking for OperatorGroup CRD existence. operandrequest-discovery and operatorgroup-namespaces-watcher will not be started")
 			}
 
 			if operatorGroupCRDExists {
+				go controllers.DiscoverOperandRequests(&crdLogger, mgr.GetClient(), mgr.GetAPIReader(), watchNamespaces, nssEnabledSemaphore)
+
 				logger := ctrl.Log.WithName("operatorgroup-namespaces-watcher")
 				removeStaleNamespacesTaskCtx, cancelRemoveStaleNamespacesTask := context.WithCancel(context.Background())
 
 				go controllers.RunRemoveStaleNamespacesFromOperatorGroupTask(removeStaleNamespacesTaskCtx, &logger, mgr.GetClient(), mgr.GetAPIReader())
 				routinesToCancel = append(routinesToCancel, cancelRemoveStaleNamespacesTask)
 			} else {
-				setupLog.Info("OperatorGroup CRD not found in cluster. operatorgroup-namespaces-watcher disabled")
+				setupLog.Info("OperatorGroup CRD not found in cluster. operandrequest-discovery and operatorgroup-namespaces-watcher disabled")
 			}
 		}
 	} else {


### PR DESCRIPTION
## Description
Run DiscoverOperandRequests only when Operator Group CRD-s exist

## Parent issue
IlS-2109

## Type
What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which modifies existing functionality)
- [ ] Dependency/version upgrade/CVE remediation
- [ ] Velocity-improvement (enhancing testing strategy, tidy code, CICD update)

## Extra information
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [x] Lint and unit tests pass locally with my changes
- [x] Tester is needed
- [ ] This change requires a documentation update - create separate issue with input for *doc* team

## Testing
- [ ] Manual tests
- [ ] Automated sert tests: <provide console log from succesful run here>
Before merging your PR, ensure Jenkins tests pass by following these steps:
1. Run the tests on the clustered environment (OCP/IKS depending on the content of the pull request) using Jenkins pipelines.
2. If the build fails due to being unstable, restart it.
3. If the failure is due to other issues unrelated to the tests themselves, address the underlying problem before proceeding.

## Test images for further QA testing (if applicable):
-
-
