### PR TITLE
Remove ClusterRoleBindings for prometheus

### DIFF
--- a/deploy/argo-cd/components/license-service/helm-cluster-scoped/templates/_helpers.tpl
+++ b/deploy/argo-cd/components/license-service/helm-cluster-scoped/templates/_helpers.tpl
@@ -25,8 +25,7 @@ limitations under the License.
 {{- and ((.Values.ibmLicensing.spec).features).nssEnabled (or ((.Values.ibmLicensing.spec).features).nodeCpuCappingEnabled ((.Values.ibmLicensing.spec).features).customResourcesEnabled ((.Values.ibmLicensing.spec).features).kubeRBACAuthEnabled) -}}
 {{- end -}}
 
-{{/* The operand ServiceAccount in use: restricted when nss is on, default otherwise.
-     Drives the cluster-monitoring-view binding subject so it follows the active SA. */}}
+{{/* The operand ServiceAccount in use: restricted when nss is on, default otherwise. */}}
 {{- define "ibm-licensing.operandServiceAccount" -}}
 {{- if ((.Values.ibmLicensing.spec).features).nssEnabled -}}
 ibm-license-service-restricted

--- a/deploy/argo-cd/components/license-service/helm-cluster-scoped/templates/cluster-rbac.yaml
+++ b/deploy/argo-cd/components/license-service/helm-cluster-scoped/templates/cluster-rbac.yaml
@@ -287,25 +287,4 @@ subjects:
   - kind: ServiceAccount
     name: ibm-licensing-operator
     namespace: {{ .Values.ibmLicensing.namespace }}
----
-{{- if eq ((.Values.ibmLicensing.spec).datasource | toString) "prometheus" }}
-# Cluster monitoring read path: needed only for datasource=prometheus; the subject follows the active operand SA.
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  labels:
-    app.kubernetes.io/instance: ibm-licensing-operator
-    app.kubernetes.io/managed-by: ibm-licensing-operator
-    app.kubernetes.io/name: ibm-licensing
-    component-id: {{ .Chart.Name }}
-  name: ibm-license-service-cluster-monitoring-view
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-monitoring-view
-subjects:
-  - kind: ServiceAccount
-    name: {{ include "ibm-licensing.operandServiceAccount" . }}
-    namespace: {{ .Values.ibmLicensing.namespace }}
-{{- end }}
 {{- end }}

--- a/helm-no-operator/templates/_helpers.tpl
+++ b/helm-no-operator/templates/_helpers.tpl
@@ -25,8 +25,7 @@ limitations under the License.
 {{- and ((.Values.ibmLicensing.spec).features).nssEnabled (or ((.Values.ibmLicensing.spec).features).nodeCpuCappingEnabled ((.Values.ibmLicensing.spec).features).customResourcesEnabled ((.Values.ibmLicensing.spec).features).kubeRBACAuthEnabled) -}}
 {{- end -}}
 
-{{/* The operand ServiceAccount in use: restricted when nss is on, default otherwise.
-     Drives the cluster-monitoring-view binding subject so it follows the active SA. */}}
+{{/* The operand ServiceAccount in use: restricted when nss is on, default otherwise. */}}
 {{- define "ibm-licensing.operandServiceAccount" -}}
 {{- if ((.Values.ibmLicensing.spec).features).nssEnabled -}}
 ibm-license-service-restricted

--- a/helm-no-operator/templates/cluster-rbac.yaml
+++ b/helm-no-operator/templates/cluster-rbac.yaml
@@ -209,25 +209,4 @@ subjects:
   - kind: ServiceAccount
     name: ibm-licensing-default-reader
     namespace: {{ .Values.ibmLicensing.namespace }}
----
-{{- if eq ((.Values.ibmLicensing.spec).datasource | toString) "prometheus" }}
-# Cluster monitoring read path: needed only for datasource=prometheus; the subject follows the active operand SA.
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  labels:
-    app.kubernetes.io/instance: ibm-licensing-operator
-    app.kubernetes.io/managed-by: ibm-licensing-operator
-    app.kubernetes.io/name: ibm-licensing
-    component-id: {{ .Chart.Name }}
-  name: ibm-license-service-cluster-monitoring-view
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-monitoring-view
-subjects:
-  - kind: ServiceAccount
-    name: {{ include "ibm-licensing.operandServiceAccount" . }}
-    namespace: {{ .Values.ibmLicensing.namespace }}
-{{- end }}
 {{- end }}


### PR DESCRIPTION
## Description
Remove ClusterRoleBindings for prometheus. Prometheus is no longer a valid datasource from the perspective of License Service API.

## Type
What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which modifies existing functionality)
- [ ] Dependency/version upgrade/CVE remediation
- [ ] Velocity-improvement (enhancing testing strategy, tidy code, CICD update)

## Extra information
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [x] Lint and unit tests pass locally with my changes
- [x] Tester is needed
- [ ] This change requires a documentation update - create separate issue with input for *doc* team

## Testing
- [x] Manual tests
- [ ] Automated sert tests: <provide console log from succesful run here>
Before merging your PR, ensure Jenkins tests pass by following these steps:
1. Run the tests on the clustered environment (OCP/IKS depending on the content of the pull request) using Jenkins pipelines.
2. If the build fails due to being unstable, restart it.
3. If the failure is due to other issues unrelated to the tests themselves, address the underlying problem before proceeding.

## Test images for further QA testing (if applicable):
-
-
