### PR TITLE
ILS-2361 Namespace exclusion

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": ".secrets.baseline|requirements.txt|go.mod|go.sum|\tpom.xml|build.gradle|package-lock.json|yarn.lock|Cargo.lock|deno.lock|composer.lock|Gemfile.lock|Pipfile.lock|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-11T07:50:42Z",
+  "generated_at": "2026-07-27T10:11:45Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -92,7 +92,7 @@
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 106,
+        "line_number": 125,
         "type": "Private Key",
         "verified_result": null
       }
@@ -120,7 +120,7 @@
         "hashed_secret": "886b85a391563800b9b7841288ad6ddcb1c1782a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 878,
+        "line_number": 877,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -128,7 +128,7 @@
         "hashed_secret": "0505ee303edffbbcb314426728ca74ac30ad2e71",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1450,
+        "line_number": 1449,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/api/v1alpha1/features.go
+++ b/api/v1alpha1/features.go
@@ -17,6 +17,8 @@
 package v1alpha1
 
 import (
+	"strings"
+
 	"github.com/IBM/ibm-licensing-operator/api/v1alpha1/features"
 )
 
@@ -46,6 +48,11 @@ type Features struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Namespace scope enabled",xDescriptors="urn:alm:descriptor:com.tectonic.ui:hidden"
 	// +optional
 	NamespaceScopeEnabled *bool `json:"nssEnabled,omitempty"`
+
+	// Comma-separated list of namespaces to exclude during aggregation. Regex patterns are also supported.
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Exclude Namespaces",xDescriptors="urn:alm:descriptor:com.tectonic.ui:text"
+	// +optional
+	ExcludeNamespace string `json:"excludeNamespace,omitempty"`
 
 	// Enables node CPU capping. When false, the operand will skip calls to the Kubernetes node API; node-capping is not applied and metrics may exceed
 	// real node capacity. Defaults to true.
@@ -82,6 +89,30 @@ func (spec *IBMLicensingSpec) HaveFeatures() bool {
 
 func (spec *IBMLicensingSpec) IsNamespaceScopeEnabled() bool {
 	return spec.HaveFeatures() && spec.Features.NamespaceScopeEnabled != nil && *spec.Features.NamespaceScopeEnabled
+}
+
+func (spec *IBMLicensingSpec) GetSanitizedExcludeNamespace() string {
+	if !spec.HaveFeatures() {
+		return ""
+	}
+
+	namespacesLookup := map[string]struct{}{}
+	dedupedNamespaces := []string{}
+
+	for namespace := range strings.SplitSeq(spec.Features.ExcludeNamespace, ",") {
+		trimmedNamespace := strings.TrimSpace(namespace)
+
+		if trimmedNamespace == "" {
+			continue
+		}
+
+		if _, ok := namespacesLookup[trimmedNamespace]; !ok {
+			namespacesLookup[trimmedNamespace] = struct{}{}
+			dedupedNamespaces = append(dedupedNamespaces, trimmedNamespace)
+		}
+	}
+
+	return strings.Join(dedupedNamespaces, ",")
 }
 
 func (spec *IBMLicensingSpec) IsKubeRBACAuthEnabled() bool {

--- a/api/v1alpha1/features.go
+++ b/api/v1alpha1/features.go
@@ -49,7 +49,7 @@ type Features struct {
 	// +optional
 	NamespaceScopeEnabled *bool `json:"nssEnabled,omitempty"`
 
-	// Comma-separated list of namespaces to exclude during aggregation. Regex patterns are also supported.
+	// Comma-separated list of namespaces to exclude during aggregation. Wildcards (".*") are also supported.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Exclude Namespaces",xDescriptors="urn:alm:descriptor:com.tectonic.ui:text"
 	// +optional
 	ExcludeNamespace string `json:"excludeNamespace,omitempty"`

--- a/api/v1alpha1/helper_test.go
+++ b/api/v1alpha1/helper_test.go
@@ -39,3 +39,57 @@ func TestIsNodeCpuCappingEnabledExplicitFalse(t *testing.T) {
 	assert.False(t, spec.IsNodeCpuCappingEnabled(),
 		"NodeCpuCappingEnabled=false should return false.")
 }
+
+func TestGetSanitizedExcludeNamespaceNoFeatures(t *testing.T) {
+	spec := &IBMLicensingSpec{}
+	assert.Equal(t, "", spec.GetSanitizedExcludeNamespace(),
+		"No features block should return empty string.")
+}
+
+func TestGetSanitizedExcludeNamespaceEmptyString(t *testing.T) {
+	spec := &IBMLicensingSpec{Features: &Features{ExcludeNamespace: ""}}
+	assert.Equal(t, "", spec.GetSanitizedExcludeNamespace(),
+		"Empty ExcludeNamespace should return empty string.")
+}
+
+func TestGetSanitizedExcludeNamespaceSingleNamespace(t *testing.T) {
+	spec := &IBMLicensingSpec{Features: &Features{ExcludeNamespace: "namespace-a"}}
+	assert.Equal(t, "namespace-a", spec.GetSanitizedExcludeNamespace(),
+		"Single namespace should be returned as-is.")
+}
+
+func TestGetSanitizedExcludeNamespaceMultipleNamespaces(t *testing.T) {
+	spec := &IBMLicensingSpec{Features: &Features{ExcludeNamespace: "namespace-a,namespace-b,namespace-c"}}
+	assert.Equal(t, "namespace-a,namespace-b,namespace-c", spec.GetSanitizedExcludeNamespace(),
+		"Multiple distinct namespaces should all be returned.")
+}
+
+func TestGetSanitizedExcludeNamespaceTrimsWhitespace(t *testing.T) {
+	spec := &IBMLicensingSpec{Features: &Features{ExcludeNamespace: " namespace-a , namespace-b , namespace-c "}}
+	assert.Equal(t, "namespace-a,namespace-b,namespace-c", spec.GetSanitizedExcludeNamespace(),
+		"Whitespace around namespace names should be trimmed.")
+}
+
+func TestGetSanitizedExcludeNamespaceRemovesDuplicates(t *testing.T) {
+	spec := &IBMLicensingSpec{Features: &Features{ExcludeNamespace: "namespace-a,namespace-b,namespace-a"}}
+	assert.Equal(t, "namespace-a,namespace-b", spec.GetSanitizedExcludeNamespace(),
+		"Duplicate namespaces should be removed, preserving first-seen order.")
+}
+
+func TestGetSanitizedExcludeNamespaceRemovesEmptyEntries(t *testing.T) {
+	spec := &IBMLicensingSpec{Features: &Features{ExcludeNamespace: "namespace-a,,namespace-b,"}}
+	assert.Equal(t, "namespace-a,namespace-b", spec.GetSanitizedExcludeNamespace(),
+		"Empty entries from consecutive commas or trailing comma should be removed.")
+}
+
+func TestGetSanitizedExcludeNamespaceRegexPattern(t *testing.T) {
+	spec := &IBMLicensingSpec{Features: &Features{ExcludeNamespace: "products-[a-zA-Z]+,database-[0-9]+"}}
+	assert.Equal(t, "products-[a-zA-Z]+,database-[0-9]+", spec.GetSanitizedExcludeNamespace(),
+		"Regex patterns should be preserved as-is.")
+}
+
+func TestGetSanitizedExcludeNamespaceWhitespaceOnlyEntry(t *testing.T) {
+	spec := &IBMLicensingSpec{Features: &Features{ExcludeNamespace: "namespace-a,   ,namespace-b"}}
+	assert.Equal(t, "namespace-a,namespace-b", spec.GetSanitizedExcludeNamespace(),
+		"Whitespace-only entries should be treated as empty and dropped.")
+}

--- a/bundle/manifests/ibm-licensing-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-licensing-operator.clusterserviceversion.yaml
@@ -81,7 +81,7 @@ metadata:
     categories: Monitoring
     certified: "false"
     containerImage: icr.io/cpopen/ibm-licensing-operator:4.2.24
-    createdAt: "2026-05-11T09:09:00Z"
+    createdAt: "2026-07-17T11:06:24Z"
     description: The IBM Licensing Operator provides a Kubernetes CRD-Based API to monitor the license usage of products.
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
@@ -219,6 +219,11 @@ spec:
             path: features.auth.urlBasedEnabled
             x-descriptors:
               - urn:alm:descriptor:com.tectonic.ui:hidden
+          - description: Comma-separated list of namespaces to exclude during aggregation. Regex patterns are also supported.
+            displayName: Exclude Namespaces
+            path: features.excludeNamespace
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
           - description: Configure if you have HyperThreading (HT) or Symmetrical Multi-Threading (SMT) enabled
             displayName: Hyper Threading
             path: features.hyperThreading

--- a/bundle/manifests/ibm-licensing-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-licensing-operator.clusterserviceversion.yaml
@@ -81,7 +81,7 @@ metadata:
     categories: Monitoring
     certified: "false"
     containerImage: icr.io/cpopen/ibm-licensing-operator:4.2.24
-    createdAt: "2026-07-17T11:06:24Z"
+    createdAt: "2026-07-27T10:07:39Z"
     description: The IBM Licensing Operator provides a Kubernetes CRD-Based API to monitor the license usage of products.
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
@@ -219,7 +219,7 @@ spec:
             path: features.auth.urlBasedEnabled
             x-descriptors:
               - urn:alm:descriptor:com.tectonic.ui:hidden
-          - description: Comma-separated list of namespaces to exclude during aggregation. Regex patterns are also supported.
+          - description: Comma-separated list of namespaces to exclude during aggregation. Wildcards (".*") are also supported.
             displayName: Exclude Namespaces
             path: features.excludeNamespace
             x-descriptors:

--- a/bundle/manifests/operator.ibm.com_ibmlicensings.yaml
+++ b/bundle/manifests/operator.ibm.com_ibmlicensings.yaml
@@ -105,6 +105,10 @@ spec:
                     description: Enables access to License Service custom resources.
                       Defaults to true.
                     type: boolean
+                  excludeNamespace:
+                    description: Comma-separated list of namespaces to exclude during
+                      aggregation. Regex patterns are also supported.
+                    type: string
                   hyperThreading:
                     description: Configure if you have HyperThreading (HT) or Symmetrical
                       Multi-Threading (SMT) enabled

--- a/bundle/manifests/operator.ibm.com_ibmlicensings.yaml
+++ b/bundle/manifests/operator.ibm.com_ibmlicensings.yaml
@@ -107,7 +107,7 @@ spec:
                     type: boolean
                   excludeNamespace:
                     description: Comma-separated list of namespaces to exclude during
-                      aggregation. Regex patterns are also supported.
+                      aggregation. Wildcards (".*") are also supported.
                     type: string
                   hyperThreading:
                     description: Configure if you have HyperThreading (HT) or Symmetrical

--- a/config/crd/bases/operator.ibm.com_ibmlicensings.yaml
+++ b/config/crd/bases/operator.ibm.com_ibmlicensings.yaml
@@ -101,6 +101,10 @@ spec:
                     description: Enables access to License Service custom resources.
                       Defaults to true.
                     type: boolean
+                  excludeNamespace:
+                    description: Comma-separated list of namespaces to exclude during
+                      aggregation. Regex patterns are also supported.
+                    type: string
                   hyperThreading:
                     description: Configure if you have HyperThreading (HT) or Symmetrical
                       Multi-Threading (SMT) enabled

--- a/config/crd/bases/operator.ibm.com_ibmlicensings.yaml
+++ b/config/crd/bases/operator.ibm.com_ibmlicensings.yaml
@@ -103,7 +103,7 @@ spec:
                     type: boolean
                   excludeNamespace:
                     description: Comma-separated list of namespaces to exclude during
-                      aggregation. Regex patterns are also supported.
+                      aggregation. Wildcards (".*") are also supported.
                     type: string
                   hyperThreading:
                     description: Configure if you have HyperThreading (HT) or Symmetrical

--- a/config/manifests/bases/ibm-licensing-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-licensing-operator.clusterserviceversion.yaml
@@ -173,6 +173,12 @@ spec:
         path: features.auth.urlBasedEnabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Comma-separated list of namespaces to exclude during aggregation.
+          Regex patterns are also supported.
+        displayName: Exclude Namespaces
+        path: features.excludeNamespace
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: Configure if you have HyperThreading (HT) or Symmetrical Multi-Threading
           (SMT) enabled
         displayName: Hyper Threading

--- a/config/manifests/bases/ibm-licensing-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-licensing-operator.clusterserviceversion.yaml
@@ -174,7 +174,7 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Comma-separated list of namespaces to exclude during aggregation.
-          Regex patterns are also supported.
+          Wildcards (".*") are also supported.
         displayName: Exclude Namespaces
         path: features.excludeNamespace
         x-descriptors:

--- a/controllers/resources/service/containers.go
+++ b/controllers/resources/service/containers.go
@@ -152,6 +152,13 @@ func getLicensingEnvironmentVariables(spec operatorv1alpha1.IBMLicensingSpec) []
 			})
 		}
 	}
+	excludeNamespace := spec.GetSanitizedExcludeNamespace()
+	if excludeNamespace != "" && !spec.IsNamespaceScopeEnabled() {
+		environmentVariables = append(environmentVariables, corev1.EnvVar{
+			Name:  "EXCLUDE_NAMESPACE",
+			Value: excludeNamespace,
+		})
+	}
 	if spec.ChargebackRetentionPeriod != nil {
 		environmentVariables = append(environmentVariables, corev1.EnvVar{
 			Name:  "CONTRIBUTIONS_DATA_RETENTION",

--- a/controllers/resources/service/containers.go
+++ b/controllers/resources/service/containers.go
@@ -33,6 +33,7 @@ const (
 	softwareCentralDefaultFrequency = "5 0 * * *"
 )
 
+//nolint:gocyclo
 func getLicensingEnvironmentVariables(spec operatorv1alpha1.IBMLicensingSpec) []corev1.EnvVar {
 	var httpsEnableString = strconv.FormatBool(spec.HTTPSEnable)
 	var environmentVariables = []corev1.EnvVar{

--- a/controllers/resources/service/containers_test.go
+++ b/controllers/resources/service/containers_test.go
@@ -296,6 +296,74 @@ func TestGetLicensingEnvironmentVariablesCustomResourcesEnabledExplicitFalse(t *
 		"CustomResourcesEnabled=false, CUSTOM_RESOURCES_ENABLED=false should be added to Licensing pod.")
 }
 
+func TestGetLicensingEnvironmentVariablesExcludeNamespaceSet(t *testing.T) {
+	spec := operatorv1alpha1.IBMLicensingSpec{
+		InstanceNamespace: "namespace",
+		Datasource:        "datacollector",
+		Features: &operatorv1alpha1.Features{
+			ExcludeNamespace: "ns-a,ns-b",
+		},
+	}
+
+	envVars := getLicensingEnvironmentVariables(spec)
+	assert.Contains(t, envVars, corev1.EnvVar{Name: "EXCLUDE_NAMESPACE", Value: "ns-a,ns-b"},
+		"ExcludeNamespace set with NSS disabled, EXCLUDE_NAMESPACE should be added to Licensing pod.")
+}
+
+func TestGetLicensingEnvironmentVariablesExcludeNamespaceNotSetWhenNSSEnabled(t *testing.T) {
+	t.Setenv("WATCH_NAMESPACE", "ibm-licensing")
+
+	spec := operatorv1alpha1.IBMLicensingSpec{
+		InstanceNamespace: "namespace",
+		Datasource:        "datacollector",
+		Features: &operatorv1alpha1.Features{
+			ExcludeNamespace:      "ns-a,ns-b",
+			NamespaceScopeEnabled: ptr.To(true),
+		},
+	}
+
+	envVars := getLicensingEnvironmentVariables(spec)
+	assert.False(t, ContainsEnvVar(envVars, "EXCLUDE_NAMESPACE"),
+		"NSS is enabled, EXCLUDE_NAMESPACE should not be added to Licensing pod.")
+}
+
+func TestGetLicensingEnvironmentVariablesExcludeNamespaceNotSetWhenEmpty(t *testing.T) {
+	spec := operatorv1alpha1.IBMLicensingSpec{
+		InstanceNamespace: "namespace",
+		Datasource:        "datacollector",
+		Features:          &operatorv1alpha1.Features{ExcludeNamespace: ""},
+	}
+
+	envVars := getLicensingEnvironmentVariables(spec)
+	assert.False(t, ContainsEnvVar(envVars, "EXCLUDE_NAMESPACE"),
+		"ExcludeNamespace is empty, EXCLUDE_NAMESPACE should not be added to Licensing pod.")
+}
+
+func TestGetLicensingEnvironmentVariablesExcludeNamespaceNotSetWhenFeaturesNil(t *testing.T) {
+	spec := operatorv1alpha1.IBMLicensingSpec{
+		InstanceNamespace: "namespace",
+		Datasource:        "datacollector",
+	}
+
+	envVars := getLicensingEnvironmentVariables(spec)
+	assert.False(t, ContainsEnvVar(envVars, "EXCLUDE_NAMESPACE"),
+		"Features is nil, EXCLUDE_NAMESPACE should not be added to Licensing pod.")
+}
+
+func TestGetLicensingEnvironmentVariablesExcludeNamespaceSanitized(t *testing.T) {
+	spec := operatorv1alpha1.IBMLicensingSpec{
+		InstanceNamespace: "namespace",
+		Datasource:        "datacollector",
+		Features: &operatorv1alpha1.Features{
+			ExcludeNamespace: " ns-a , ns-b , ns-a ",
+		},
+	}
+
+	envVars := getLicensingEnvironmentVariables(spec)
+	assert.Contains(t, envVars, corev1.EnvVar{Name: "EXCLUDE_NAMESPACE", Value: "ns-a,ns-b"},
+		"ExcludeNamespace with whitespace and duplicates should be sanitized before being set as env var.")
+}
+
 func Contains[T comparable](s []T, e T) bool {
 	for _, v := range s {
 		if v == e {

--- a/deploy/argo-cd/components/license-service/helm-cluster-scoped/templates/cr.yaml
+++ b/deploy/argo-cd/components/license-service/helm-cluster-scoped/templates/cr.yaml
@@ -21,4 +21,9 @@ spec:
     {{- $_ := set $imagePullData "imagePullSecrets" (prepend (default list .Values.ibmLicensing.spec.imagePullSecrets) .Values.global.imagePullSecret | uniq) -}}
   {{- end -}}
 
+  {{- /* Propagate top-level excludeNamespace into spec.features.excludeNamespace */ -}}
+  {{- if .Values.ibmLicensing.excludeNamespace -}}
+    {{- $_ := set $imagePullData "features" (mergeOverwrite (default dict ((.Values.ibmLicensing.spec).features)) (dict "excludeNamespace" .Values.ibmLicensing.excludeNamespace)) -}}
+  {{- end -}}
+
   {{- toYaml (mergeOverwrite .Values.ibmLicensing.spec $imagePullData) | nindent 2 }}

--- a/deploy/argo-cd/components/license-service/helm-cluster-scoped/templates/crd.yaml
+++ b/deploy/argo-cd/components/license-service/helm-cluster-scoped/templates/crd.yaml
@@ -366,6 +366,10 @@ spec:
                     customResourcesEnabled:
                       description: Enables access to License Service custom resources. Defaults to true.
                       type: boolean
+                    excludeNamespace:
+                      description: Comma-separated list of namespaces to exclude
+                        during aggregation. Regex patterns are also supported.
+                      type: string
                     hyperThreading:
                       description: Configure if you have HyperThreading (HT) or Symmetrical Multi-Threading (SMT) enabled
                       properties:

--- a/deploy/argo-cd/components/license-service/helm-cluster-scoped/templates/crd.yaml
+++ b/deploy/argo-cd/components/license-service/helm-cluster-scoped/templates/crd.yaml
@@ -367,8 +367,8 @@ spec:
                       description: Enables access to License Service custom resources. Defaults to true.
                       type: boolean
                     excludeNamespace:
-                      description: Comma-separated list of namespaces to exclude
-                        during aggregation. Regex patterns are also supported.
+                      description: Comma-separated list of namespaces to exclude during
+                        aggregation. Wildcards (".*") are also supported.
                       type: string
                     hyperThreading:
                       description: Configure if you have HyperThreading (HT) or Symmetrical Multi-Threading (SMT) enabled

--- a/deploy/argo-cd/components/license-service/helm-cluster-scoped/values.yaml
+++ b/deploy/argo-cd/components/license-service/helm-cluster-scoped/values.yaml
@@ -6,6 +6,7 @@ global:
 ibmLicensing:
   namespace: ibm-licensing
   watchNamespace: ibm-licensing
+  excludeNamespace: ""
   imageRegistryNamespaceOperator: cpopen
   imageRegistryNamespaceOperand: cpopen/cpfs
   createRBAC: true
@@ -16,7 +17,6 @@ ibmLicensing:
     httpsEnable: true
     features:
       nssEnabled: false
-      excludeNamespace: ""
       nodeCpuCappingEnabled: true
       kubeRBACAuthEnabled: true
       operandRequestsEnabled: true

--- a/deploy/argo-cd/components/license-service/helm-cluster-scoped/values.yaml
+++ b/deploy/argo-cd/components/license-service/helm-cluster-scoped/values.yaml
@@ -16,6 +16,7 @@ ibmLicensing:
     httpsEnable: true
     features:
       nssEnabled: false
+      excludeNamespace: ""
       nodeCpuCappingEnabled: true
       kubeRBACAuthEnabled: true
       operandRequestsEnabled: true

--- a/helm-no-operator/templates/deployment.yaml
+++ b/helm-no-operator/templates/deployment.yaml
@@ -66,9 +66,9 @@ spec:
               value: {{ .Values.ibmLicensing.spec.features.kubeRBACAuthEnabled | quote }}
             - name: CUSTOM_RESOURCES_ENABLED
               value: {{ .Values.ibmLicensing.spec.features.customResourcesEnabled | quote }}
-            {{- if and (not .Values.ibmLicensing.spec.features.nssEnabled) (.Values.ibmLicensing.spec.features.excludeNamespace) }}
+            {{- if and (not .Values.ibmLicensing.spec.features.nssEnabled) (.Values.ibmLicensing.excludeNamespace) }}
             - name: EXCLUDE_NAMESPACE
-              value: {{ .Values.ibmLicensing.spec.features.excludeNamespace | quote }}
+              value: {{ .Values.ibmLicensing.excludeNamespace | quote }}
             {{- end }}
           image: {{ .Values.global.imagePullPrefix }}/{{ .Values.ibmLicensing.imageRegistryNamespaceOperand }}/ibm-licensing:{{ .Values.ibmLicensing.ibmLicensingVersion }}
           imagePullPolicy: IfNotPresent
@@ -162,9 +162,9 @@ spec:
               value: {{ .Values.ibmLicensing.spec.features.kubeRBACAuthEnabled | quote }}
             - name: CUSTOM_RESOURCES_ENABLED
               value: {{ .Values.ibmLicensing.spec.features.customResourcesEnabled | quote }}
-            {{- if and (not .Values.ibmLicensing.spec.features.nssEnabled) (.Values.ibmLicensing.spec.features.excludeNamespace) }}
+            {{- if and (not .Values.ibmLicensing.spec.features.nssEnabled) (.Values.ibmLicensing.excludeNamespace) }}
             - name: EXCLUDE_NAMESPACE
-              value: {{ .Values.ibmLicensing.spec.features.excludeNamespace | quote }}
+              value: {{ .Values.ibmLicensing.excludeNamespace | quote }}
             {{- end }}
           image: {{ .Values.global.imagePullPrefix }}/{{ .Values.ibmLicensing.imageRegistryNamespaceOperand }}/ibm-licensing:{{ .Values.ibmLicensing.ibmLicensingVersion }}
           imagePullPolicy: IfNotPresent

--- a/helm-no-operator/templates/deployment.yaml
+++ b/helm-no-operator/templates/deployment.yaml
@@ -66,6 +66,10 @@ spec:
               value: {{ .Values.ibmLicensing.spec.features.kubeRBACAuthEnabled | quote }}
             - name: CUSTOM_RESOURCES_ENABLED
               value: {{ .Values.ibmLicensing.spec.features.customResourcesEnabled | quote }}
+            {{- if and (not .Values.ibmLicensing.spec.features.nssEnabled) (.Values.ibmLicensing.spec.features.excludeNamespace) }}
+            - name: EXCLUDE_NAMESPACE
+              value: {{ .Values.ibmLicensing.spec.features.excludeNamespace | quote }}
+            {{- end }}
           image: {{ .Values.global.imagePullPrefix }}/{{ .Values.ibmLicensing.imageRegistryNamespaceOperand }}/ibm-licensing:{{ .Values.ibmLicensing.ibmLicensingVersion }}
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -158,6 +162,10 @@ spec:
               value: {{ .Values.ibmLicensing.spec.features.kubeRBACAuthEnabled | quote }}
             - name: CUSTOM_RESOURCES_ENABLED
               value: {{ .Values.ibmLicensing.spec.features.customResourcesEnabled | quote }}
+            {{- if and (not .Values.ibmLicensing.spec.features.nssEnabled) (.Values.ibmLicensing.spec.features.excludeNamespace) }}
+            - name: EXCLUDE_NAMESPACE
+              value: {{ .Values.ibmLicensing.spec.features.excludeNamespace | quote }}
+            {{- end }}
           image: {{ .Values.global.imagePullPrefix }}/{{ .Values.ibmLicensing.imageRegistryNamespaceOperand }}/ibm-licensing:{{ .Values.ibmLicensing.ibmLicensingVersion }}
           imagePullPolicy: IfNotPresent
           name: ocp-check-secret

--- a/helm-no-operator/values.yaml
+++ b/helm-no-operator/values.yaml
@@ -19,6 +19,7 @@ ibmLicensing:
     enableInstanaMetricCollection: false
     features:
       nssEnabled: false
+      excludeNamespace: ""
       nodeCpuCappingEnabled: true
       kubeRBACAuthEnabled: true
       customResourcesEnabled: true

--- a/helm-no-operator/values.yaml
+++ b/helm-no-operator/values.yaml
@@ -7,6 +7,7 @@ global:
 ibmLicensing:
   namespace: ibm-licensing
   watchNamespace: ibm-licensing
+  excludeNamespace: ""
   imageRegistryNamespaceOperand: cpopen/cpfs
   ibmLicensingVersion: 4.2.24
   createRBAC: true
@@ -19,7 +20,6 @@ ibmLicensing:
     enableInstanaMetricCollection: false
     features:
       nssEnabled: false
-      excludeNamespace: ""
       nodeCpuCappingEnabled: true
       kubeRBACAuthEnabled: true
       customResourcesEnabled: true


### PR DESCRIPTION
## Description

Adds `spec.features.excludeNamespace` to the IBMLicensing CR - a comma-separated list of namespace names or regex patterns that the operand should skip during aggregation. The operator sanitizes the value (trims whitespace, removes duplicates and empty entries) and injects it into the operand pod as the `EXCLUDE_NAMESPACE` environment variable. The env var is suppressed entirely when namespace scoping (`nssEnabled`) is active. The helm chart (`helm-no-operator` and the ArgoCD deployment) is updated with the new field, and the CRD manifests are regenerated.

## Parent issue
ILS-2361

## Type
What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which modifies existing functionality)
- [ ] Dependency/version upgrade/CVE remediation
- [ ] Velocity-improvement (enhancing testing strategy, tidy code, CICD update)

## Extra information
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] Lint and unit tests pass locally with my changes
- [x] Tester is needed
- [x] This change requires a documentation update - create separate issue with input for *doc* team

## Testing
- [x] Manual tests
- [ ] Automated sert tests: <provide console log from succesful run here>
Before merging your PR, ensure Jenkins tests pass by following these steps:
1. Run the tests on the clustered environment (OCP/IKS depending on the content of the pull request) using Jenkins pipelines.
2. If the build fails due to being unstable, restart it.
3. If the failure is due to other issues unrelated to the tests themselves, address the underlying problem before proceeding.

## Test images for further QA testing (if applicable):
-
-
