### PR TITLE
adding support for version number metadata annotation licensing.ibm.c…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -421,6 +421,15 @@ manifests: controller-gen yq
 	$(YQ) -i '.metadata.annotations."olm.skipRange" = ">=1.0.0 <$(CSV_VERSION)"' ./config/manifests/bases/ibm-licensing-operator.clusterserviceversion.yaml
 	$(YQ) -i '.metadata.annotations.containerImage = "icr.io/cpopen/${IMG}:$(CSV_VERSION)"' ./config/manifests/bases/ibm-licensing-operator.clusterserviceversion.yaml
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=ibm-licensing-operator webhook paths="./api/..." paths="./controllers/..." output:crd:artifacts:config=config/crd/bases
+	# Stamp licensing.ibm.com/version into generated CRDs and resolve placeholder to CSV_VERSION
+	@$(YQ) -i '.metadata.annotations."licensing.ibm.com/version" = "sed-me-ils-version"' config/crd/bases/operator.ibm.com_ibmlicensingdefinitions.yaml
+	@$(YQ) -i '.metadata.annotations."licensing.ibm.com/version" = "sed-me-ils-version"' config/crd/bases/operator.ibm.com_ibmlicensingmetadatas.yaml
+	@$(YQ) -i '.metadata.annotations."licensing.ibm.com/version" = "sed-me-ils-version"' config/crd/bases/operator.ibm.com_ibmlicensingquerysources.yaml
+	@$(YQ) -i '.metadata.annotations."licensing.ibm.com/version" = "sed-me-ils-version"' config/crd/bases/operator.ibm.com_ibmlicensings.yaml
+	@sed -i '' "s/sed-me-ils-version/$(CSV_VERSION)/g" config/crd/bases/operator.ibm.com_ibmlicensingdefinitions.yaml
+	@sed -i '' "s/sed-me-ils-version/$(CSV_VERSION)/g" config/crd/bases/operator.ibm.com_ibmlicensingmetadatas.yaml
+	@sed -i '' "s/sed-me-ils-version/$(CSV_VERSION)/g" config/crd/bases/operator.ibm.com_ibmlicensingquerysources.yaml
+	@sed -i '' "s/sed-me-ils-version/$(CSV_VERSION)/g" config/crd/bases/operator.ibm.com_ibmlicensings.yaml
 
 # Generate code
 generate: controller-gen
@@ -777,6 +786,10 @@ generate-yaml-argo-cd: kustomize yq
 	# This sync wave is crucial because the deployment must be created after the CR, to avoid a situation when ArgoCD
 	# starts creating the CR at the same time as the operator does it (patch isn't applied and a name conflict happens)
 	@$(YQ) -i '.metadata.annotations."argocd.argoproj.io/sync-wave" = "1"' argo-cd/deployment.yaml
+
+	# Replace licensing.ibm.com/version with helm chart version template
+	@$(YQ) -i '.metadata.annotations."licensing.ibm.com/version" = "sed-me-ils-version"' argo-cd/crd.yaml
+	@sed -i '' "s/sed-me-ils-version/{{ .Chart.Version }}/g" argo-cd/crd.yaml
 
 	# Replace all component-id labels to template them with helm
 	@sed -i '' "s/component-id: sed-me/component-id: {{ .Chart.Name }}/g" argo-cd/cluster-rbac.yaml

--- a/bundle/manifests/operator.ibm.com_ibmlicensingdefinitions.yaml
+++ b/bundle/manifests/operator.ibm.com_ibmlicensingdefinitions.yaml
@@ -3,6 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.1
+    licensing.ibm.com/version: sed-me-ils-version
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: ibm-licensing-operator

--- a/bundle/manifests/operator.ibm.com_ibmlicensingmetadatas.yaml
+++ b/bundle/manifests/operator.ibm.com_ibmlicensingmetadatas.yaml
@@ -3,6 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.1
+    licensing.ibm.com/version: sed-me-ils-version
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: ibm-licensing-operator

--- a/bundle/manifests/operator.ibm.com_ibmlicensingquerysources.yaml
+++ b/bundle/manifests/operator.ibm.com_ibmlicensingquerysources.yaml
@@ -3,6 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.1
+    licensing.ibm.com/version: sed-me-ils-version
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: ibm-licensing-operator

--- a/bundle/manifests/operator.ibm.com_ibmlicensings.yaml
+++ b/bundle/manifests/operator.ibm.com_ibmlicensings.yaml
@@ -3,6 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.1
+    licensing.ibm.com/version: sed-me-ils-version
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: ibm-licensing-operator

--- a/config/crd/bases/operator.ibm.com_ibmlicensingdefinitions.yaml
+++ b/config/crd/bases/operator.ibm.com_ibmlicensingdefinitions.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.1
+    licensing.ibm.com/version: 4.2.24
   name: ibmlicensingdefinitions.operator.ibm.com
 spec:
   group: operator.ibm.com
@@ -14,84 +15,82 @@ spec:
     singular: ibmlicensingdefinition
   scope: Namespaced
   versions:
-  - name: v1
-    schema:
-      openAPIV3Schema:
-        description: |-
-          IBMLicensingDefinition is a custom resource for internal use only. It is used by some IBM products to assign their pods to the licensed products for the licensing specific calculation, performed by the IBM License Service.
-          It is prepared in close collaboration with those IBM products, and affects only them. It cannot be modified by a customer, to ensure compliance with the license usage metering and reporting.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: IBMLicensingDefinitionSpec defines the desired state of IBMLicensingDefinition
-            properties:
-              action:
-                description: Action of Custom Resource
-                enum:
-                - modifyOriginal
-                - cloneModify
-                type: string
-              condition:
-                description: Condition used to match pods
-                properties:
-                  metadata:
-                    properties:
-                      annotations:
-                        additionalProperties:
-                          type: string
-                        description: List of annotations used for matching pod
-                        type: object
-                      labels:
-                        additionalProperties:
-                          type: string
-                        description: List of labels used for matching pod
-                        type: object
-                    type: object
-                type: object
-              remove:
-                description: List of annotation keys that will be removed from matched
-                  pod
-                items:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            IBMLicensingDefinition is a custom resource for internal use only. It is used by some IBM products to assign their pods to the licensed products for the licensing specific calculation, performed by the IBM License Service.
+            It is prepared in close collaboration with those IBM products, and affects only them. It cannot be modified by a customer, to ensure compliance with the license usage metering and reporting.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: IBMLicensingDefinitionSpec defines the desired state of IBMLicensingDefinition
+              properties:
+                action:
+                  description: Action of Custom Resource
+                  enum:
+                    - modifyOriginal
+                    - cloneModify
                   type: string
-                type: array
-              scope:
-                description: Scope of Custom Resource
-                enum:
-                - cluster
-                type: string
-              set:
-                additionalProperties:
+                condition:
+                  description: Condition used to match pods
+                  properties:
+                    metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: List of annotations used for matching pod
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: List of labels used for matching pod
+                          type: object
+                      type: object
+                  type: object
+                remove:
+                  description: List of annotation keys that will be removed from matched pod
+                  items:
+                    type: string
+                  type: array
+                scope:
+                  description: Scope of Custom Resource
+                  enum:
+                    - cluster
                   type: string
-                description: List of annotations that matched pod would be extended
-                type: object
-            required:
-            - action
-            - condition
-            - scope
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            description: IBMLicensingDefinitionStatus defines the observed state of
-              IBMLicensingDefinition
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                set:
+                  additionalProperties:
+                    type: string
+                  description: List of annotations that matched pod would be extended
+                  type: object
+              required:
+                - action
+                - condition
+                - scope
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              description: IBMLicensingDefinitionStatus defines the observed state of IBMLicensingDefinition
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/config/crd/bases/operator.ibm.com_ibmlicensingmetadatas.yaml
+++ b/config/crd/bases/operator.ibm.com_ibmlicensingmetadatas.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.1
+    licensing.ibm.com/version: 4.2.24
   name: ibmlicensingmetadatas.operator.ibm.com
 spec:
   group: operator.ibm.com
@@ -14,64 +15,63 @@ spec:
     singular: ibmlicensingmetadata
   scope: Namespaced
   versions:
-  - deprecated: true
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: |-
-          IBMLicensingMetadata is the schema for IBM License Service. Thanks to IBMLicensingMetadata, you can track
-          the license usage of Virtual Processor Core (VPC) metric by Pods that are managed by automation,
-          for which licensing annotations are not defined at the time of deployment, such as the open source OpenLiberty.
-          / For more information, see documentation: https://ibm.biz/icpfs39install.
-          License: By installing this product you accept the license terms. For more information about the license,
-          see https://ibm.biz/icpfs39license.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: IBMLicensingMetadataSpec defines the desired state of IBMLicensingMetadata
-            properties:
-              condition:
-                properties:
-                  annotation:
-                    additionalProperties:
-                      type: string
-                    description: List of annotations used for matching pod
-                    type: object
-                required:
-                - annotation
-                type: object
-              extend:
-                additionalProperties:
-                  type: string
-                description: List of annotations that matched pod would be extended
-                type: object
-            required:
-            - condition
-            - extend
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            description: IBMLicensingMetadataStatus defines the observed state of
-              IBMLicensingMetadata
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+    - deprecated: true
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            IBMLicensingMetadata is the schema for IBM License Service. Thanks to IBMLicensingMetadata, you can track
+            the license usage of Virtual Processor Core (VPC) metric by Pods that are managed by automation,
+            for which licensing annotations are not defined at the time of deployment, such as the open source OpenLiberty.
+            / For more information, see documentation: https://ibm.biz/icpfs39install.
+            License: By installing this product you accept the license terms. For more information about the license,
+            see https://ibm.biz/icpfs39license.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: IBMLicensingMetadataSpec defines the desired state of IBMLicensingMetadata
+              properties:
+                condition:
+                  properties:
+                    annotation:
+                      additionalProperties:
+                        type: string
+                      description: List of annotations used for matching pod
+                      type: object
+                  required:
+                    - annotation
+                  type: object
+                extend:
+                  additionalProperties:
+                    type: string
+                  description: List of annotations that matched pod would be extended
+                  type: object
+              required:
+                - condition
+                - extend
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              description: IBMLicensingMetadataStatus defines the observed state of IBMLicensingMetadata
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/config/crd/bases/operator.ibm.com_ibmlicensingquerysources.yaml
+++ b/config/crd/bases/operator.ibm.com_ibmlicensingquerysources.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.1
+    licensing.ibm.com/version: 4.2.24
   name: ibmlicensingquerysources.operator.ibm.com
 spec:
   group: operator.ibm.com
@@ -14,63 +15,58 @@ spec:
     singular: ibmlicensingquerysource
   scope: Namespaced
   versions:
-  - name: v1
-    schema:
-      openAPIV3Schema:
-        description: |-
-          IBMLicensingQuerySource is a custom resource for internal use only. It is used by some IBM products to assign their pods to the licensed products for the licensing specific calculation, performed by the IBM License Service.
-          It is prepared in close collaboration with those IBM products, and affects only them. It cannot be modified by a customer, to ensure compliance with the license usage metering and reporting.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: IBMLicensingQuerySourceSpec defines the desired state of
-              IBMLicensingQuerySource
-            properties:
-              aggregationPolicy:
-                description: Policy on how should newly queried data be aggregated
-                  to previous data (defaults to MAX)
-                enum:
-                - MAX
-                - ADD
-                - ADD_MONTHLY
-                type: string
-              annotations:
-                additionalProperties:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            IBMLicensingQuerySource is a custom resource for internal use only. It is used by some IBM products to assign their pods to the licensed products for the licensing specific calculation, performed by the IBM License Service.
+            It is prepared in close collaboration with those IBM products, and affects only them. It cannot be modified by a customer, to ensure compliance with the license usage metering and reporting.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: IBMLicensingQuerySourceSpec defines the desired state of IBMLicensingQuerySource
+              properties:
+                aggregationPolicy:
+                  description: Policy on how should newly queried data be aggregated to previous data (defaults to MAX)
+                  enum:
+                    - MAX
+                    - ADD
+                    - ADD_MONTHLY
                   type: string
-                description: Product and cloudpak annotations mapping the query to
-                  licensing usage
-                type: object
-              query:
-                description: What query should be send to prometheuses to get the
-                  licensing usage
-                type: string
-            required:
-            - annotations
-            - query
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            description: IBMLicensingQuerySourceStatus defines the observed state
-              of IBMLicensingQuerySource
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                annotations:
+                  additionalProperties:
+                    type: string
+                  description: Product and cloudpak annotations mapping the query to licensing usage
+                  type: object
+                query:
+                  description: What query should be send to prometheuses to get the licensing usage
+                  type: string
+              required:
+                - annotations
+                - query
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              description: IBMLicensingQuerySourceStatus defines the observed state of IBMLicensingQuerySource
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/config/crd/bases/operator.ibm.com_ibmlicensings.yaml
+++ b/config/crd/bases/operator.ibm.com_ibmlicensings.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.1
+    licensing.ibm.com/version: 4.2.24
   name: ibmlicensings.operator.ibm.com
 spec:
   group: operator.ibm.com
@@ -14,2030 +15,1868 @@ spec:
     singular: ibmlicensing
   scope: Cluster
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .status..phase
-      name: Pod Phase
-      type: string
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: |-
-          IBMLicensing custom resource is used to create an instance of the License Service, used to collect information about license usage of IBM containerized products and IBM Cloud Paks per cluster.
-          You can retrieve license usage data through a dedicated API call and generate an audit snapshot on demand.
-          Documentation: For additional details regarding install parameters check: https://ibm.biz/icpfs39install.
-          License: Please refer to the IBM Terms website (ibm.biz/lsvc-lic)
-          to find the license terms for the particular IBM product for which you are deploying this component.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: IBMLicensingSpec defines the desired state of IBMLicensing
-            properties:
-              annotations:
-                additionalProperties:
-                  type: string
-                description: Annotations to be copied into all relevant resources
-                type: object
-              apiSecretToken:
-                description: Secret name used to store application token, either one
-                  that exists, or one that will be created
-                type: string
-              chargebackEnabled:
-                description: Consider updating to enable chargeback feature
-                type: boolean
-              chargebackRetentionPeriod:
-                description: Chargeback data retention period in days. Default value
-                  is 62 days.
-                type: integer
-              datasource:
-                description: 'Where should data be collected, options: metering, datacollector'
-                enum:
-                - metering
-                - datacollector
-                type: string
-              enableInstanaMetricCollection:
-                description: Enabling collection of Instana metrics
-                type: boolean
-              envVariable:
-                additionalProperties:
-                  type: string
-                description: Environment variable setting
-                type: object
-              features:
-                description: Set additional features under this field
-                properties:
-                  alerting:
-                    description: Change alerting settings.
-                    properties:
-                      enabled:
-                        description: Should this function be enabled.
-                        type: boolean
-                    type: object
-                  auth:
-                    description: Authorization settings.
-                    properties:
-                      urlBasedEnabled:
-                        description: Enable URL based Auth
-                        type: boolean
-                    required:
-                    - urlBasedEnabled
-                    type: object
-                  customResourcesEnabled:
-                    description: Enables access to License Service custom resources.
-                      Defaults to true.
-                    type: boolean
-                  hyperThreading:
-                    description: Configure if you have HyperThreading (HT) or Symmetrical
-                      Multi-Threading (SMT) enabled
-                    properties:
-                      threadsPerCore:
-                        description: Set the value based on the lowest HT/SMT value
-                          based on the lowest configuration of worker nodes
-                        enum:
-                        - 1
-                        - 2
-                        - 4
-                        - 8
-                        type: integer
-                    required:
-                    - threadsPerCore
-                    type: object
-                  kubeRBACAuthEnabled:
-                    description: Enables the bearer-token / Kubernetes RBAC authentication
-                      path on the operand (TokenReview + SubjectAccessReview). Defaults
-                      to true.
-                    type: boolean
-                  nodeCpuCappingEnabled:
-                    description: |-
-                      Enables node CPU capping. When false, the operand will skip calls to the Kubernetes node API; node-capping is not applied and metrics may exceed
-                      real node capacity. Defaults to true.
-                    type: boolean
-                  nssConfigMap:
-                    description: Special terms, must be granted by IBM Pricing.
+    - additionalPrinterColumns:
+        - jsonPath: .status..phase
+          name: Pod Phase
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            IBMLicensing custom resource is used to create an instance of the License Service, used to collect information about license usage of IBM containerized products and IBM Cloud Paks per cluster.
+            You can retrieve license usage data through a dedicated API call and generate an audit snapshot on demand.
+            Documentation: For additional details regarding install parameters check: https://ibm.biz/icpfs39install.
+            License: Please refer to the IBM Terms website (ibm.biz/lsvc-lic)
+            to find the license terms for the particular IBM product for which you are deploying this component.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: IBMLicensingSpec defines the desired state of IBMLicensing
+              properties:
+                annotations:
+                  additionalProperties:
                     type: string
-                  nssDenialLimit:
-                    description: Limit for failed namespace access attempts before
-                      reporting an error in custom namespaces scoping.
-                    type: integer
-                  nssEnabled:
-                    description: |-
-                      Restricts IBM License Service to watching only the namespaces specified in the WATCH_NAMESPACE operator environment variable or in the ConfigMap referenced by .features.nssConfigMap.
-                      This feature requires authorization from IBM Pricing.
-                    type: boolean
-                  operandRequestsEnabled:
-                    description: Enables the OperandRequest integration. Defaults
-                      to true.
-                    type: boolean
-                  prometheusQuerySource:
-                    description: Change prometheus query source settings.
-                    properties:
-                      enabled:
-                        description: Should this function be enabled (by default it
-                          is).
-                        type: boolean
-                      url:
-                        description: What url to use for prometheus API (by default
-                          use OCP Thanos Querier).
-                        type: string
-                    type: object
-                type: object
-              gatewayEnabled:
-                default: true
-                description: Should Gateway be created to expose IBM Licensing Service
-                  API? Default is true.
-                type: boolean
-              gatewayOptions:
-                description: If Gateway is enabled, you can set its parameters
-                properties:
-                  annotations:
-                    additionalProperties:
-                      type: string
-                    description: Additional annotations that should include f.e. gateway
-                      class if using not default gateway controller
-                    type: object
-                  enableGatewayAPIOpenshift:
-                    default: false
-                    description: Switch for enabling Gateway API on Openshift. Default
-                      is false.
-                    type: boolean
-                  gatewayClassName:
-                    default: ibm-licensing
-                    description: GatewayClassName defines gateway class name option
-                      to be passed to the gateway spec field. Default is ibm-licensing.
-                    type: string
-                  httpsPort:
-                    default: 443
-                    description: HTTPS port for Gateway listener. Default is 443.
-                      Only used when TLSSecretName is set.
-                    format: int32
-                    maximum: 65535
-                    minimum: 1
-                    type: integer
-                  tlsSecretName:
-                    default: ibm-license-service-cert-internal
-                    description: TLS Options to enable secure connection. Default
-                      is ibm-license-service-cert-internal.
-                    type: string
-                type: object
-              httpsCertsSource:
-                description: 'options: self-signed or custom'
-                enum:
-                - self-signed
-                - custom
-                - ocp
-                type: string
-              httpsEnable:
-                description: Enables https access at pod level, httpsCertsSource needed
-                  if true
-                type: boolean
-              imageName:
-                description: IBM Licensing Service docker Image Name, will override
-                  default value and disable IBM_LICENSING_IMAGE env value in operator
-                  deployment
-                type: string
-              imagePullPolicy:
-                description: PullPolicy describes a policy for if/when to pull a container
-                  image
-                enum:
-                - Always
-                - IfNotPresent
-                - Never
-                type: string
-              imagePullSecrets:
-                description: Array of pull secrets which should include existing at
-                  InstanceNamespace secret to allow pulling IBM Licensing image
-                items:
+                  description: Annotations to be copied into all relevant resources
+                  type: object
+                apiSecretToken:
+                  description: Secret name used to store application token, either one that exists, or one that will be created
                   type: string
-                type: array
-              imageRegistry:
-                description: IBM Licensing Service docker Image Registry, will override
-                  default value and disable IBM_LICENSING_IMAGE env value in operator
-                  deployment
-                type: string
-              imageTagPostfix:
-                description: IBM Licensing Service docker Image Tag or Digest, will
-                  override default value and disable IBM_LICENSING_IMAGE env value
-                  in operator deployment
-                type: string
-              instanceNamespace:
-                description: |-
-                  Existing or to be created namespace where application will start. In case metering data collection is used,
-                  should be the same namespace as metering components
-                type: string
-              labels:
-                additionalProperties:
+                chargebackEnabled:
+                  description: Consider updating to enable chargeback feature
+                  type: boolean
+                chargebackRetentionPeriod:
+                  description: Chargeback data retention period in days. Default value is 62 days.
+                  type: integer
+                datasource:
+                  description: 'Where should data be collected, options: metering, datacollector'
+                  enum:
+                    - metering
+                    - datacollector
                   type: string
-                description: Labels to be copied into all relevant resources
-                type: object
-              license:
-                description: IBM License Service license acceptance.
-                properties:
-                  accept:
-                    description: 'By installing the IBM License Service, you accept
-                      the license terms for the particular IBM product for which you
-                      are deploying this component: ibm.biz/lsvc-lic.'
-                    type: boolean
-                type: object
-              logLevel:
-                description: 'Should application pod show additional information,
-                  options: DEBUG, INFO, VERBOSE'
-                enum:
-                - DEBUG
-                - INFO
-                - VERBOSE
-                type: string
-              resources:
-                description: ResourceRequirements describes the compute resource requirements.
-                properties:
-                  claims:
-                    description: |-
-                      Claims lists the names of resources, defined in spec.resourceClaims,
-                      that are used by this container.
-
-                      This field depends on the
-                      DynamicResourceAllocation feature gate.
-
-                      This field is immutable. It can only be set for containers.
-                    items:
-                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                enableInstanaMetricCollection:
+                  description: Enabling collection of Instana metrics
+                  type: boolean
+                envVariable:
+                  additionalProperties:
+                    type: string
+                  description: Environment variable setting
+                  type: object
+                features:
+                  description: Set additional features under this field
+                  properties:
+                    alerting:
+                      description: Change alerting settings.
                       properties:
-                        name:
-                          description: |-
-                            Name must match the name of one entry in pod.spec.resourceClaims of
-                            the Pod where this field is used. It makes that resource available
-                            inside a container.
-                          type: string
-                        request:
-                          description: |-
-                            Request is the name chosen for a request in the referenced claim.
-                            If empty, everything from the claim is made available, otherwise
-                            only the result of this request.
-                          type: string
-                      required:
-                      - name
+                        enabled:
+                          description: Should this function be enabled.
+                          type: boolean
                       type: object
-                    type: array
-                    x-kubernetes-list-map-keys:
-                    - name
-                    x-kubernetes-list-type: map
-                  limits:
-                    additionalProperties:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      x-kubernetes-int-or-string: true
-                    description: |-
-                      Limits describes the maximum amount of compute resources allowed.
-                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                    type: object
-                  requests:
-                    additionalProperties:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      x-kubernetes-int-or-string: true
-                    description: |-
-                      Requests describes the minimum amount of compute resources required.
-                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                    type: object
-                type: object
-              rhmpEnabled:
-                description: Is Red Hat Marketplace enabled
-                type: boolean
-              routeEnabled:
-                description: Should Route be created to expose IBM Licensing Service
-                  API? (only on OpenShift cluster)
-                type: boolean
-              routeOptions:
-                description: Route parameters
-                properties:
-                  tls:
-                    description: TLSConfig defines config used to secure a route and
-                      provide termination
-                    properties:
-                      caCertificate:
-                        description: caCertificate provides the cert authority certificate
-                          contents
+                    auth:
+                      description: Authorization settings.
+                      properties:
+                        urlBasedEnabled:
+                          description: Enable URL based Auth
+                          type: boolean
+                      required:
+                        - urlBasedEnabled
+                      type: object
+                    customResourcesEnabled:
+                      description: Enables access to License Service custom resources. Defaults to true.
+                      type: boolean
+                    hyperThreading:
+                      description: Configure if you have HyperThreading (HT) or Symmetrical Multi-Threading (SMT) enabled
+                      properties:
+                        threadsPerCore:
+                          description: Set the value based on the lowest HT/SMT value based on the lowest configuration of worker nodes
+                          enum:
+                            - 1
+                            - 2
+                            - 4
+                            - 8
+                          type: integer
+                      required:
+                        - threadsPerCore
+                      type: object
+                    kubeRBACAuthEnabled:
+                      description: Enables the bearer-token / Kubernetes RBAC authentication path on the operand (TokenReview + SubjectAccessReview). Defaults to true.
+                      type: boolean
+                    nodeCpuCappingEnabled:
+                      description: |-
+                        Enables node CPU capping. When false, the operand will skip calls to the Kubernetes node API; node-capping is not applied and metrics may exceed
+                        real node capacity. Defaults to true.
+                      type: boolean
+                    nssConfigMap:
+                      description: Special terms, must be granted by IBM Pricing.
+                      type: string
+                    nssDenialLimit:
+                      description: Limit for failed namespace access attempts before reporting an error in custom namespaces scoping.
+                      type: integer
+                    nssEnabled:
+                      description: |-
+                        Restricts IBM License Service to watching only the namespaces specified in the WATCH_NAMESPACE operator environment variable or in the ConfigMap referenced by .features.nssConfigMap.
+                        This feature requires authorization from IBM Pricing.
+                      type: boolean
+                    operandRequestsEnabled:
+                      description: Enables the OperandRequest integration. Defaults to true.
+                      type: boolean
+                    prometheusQuerySource:
+                      description: Change prometheus query source settings.
+                      properties:
+                        enabled:
+                          description: Should this function be enabled (by default it is).
+                          type: boolean
+                        url:
+                          description: What url to use for prometheus API (by default use OCP Thanos Querier).
+                          type: string
+                      type: object
+                  type: object
+                gatewayEnabled:
+                  default: true
+                  description: Should Gateway be created to expose IBM Licensing Service API? Default is true.
+                  type: boolean
+                gatewayOptions:
+                  description: If Gateway is enabled, you can set its parameters
+                  properties:
+                    annotations:
+                      additionalProperties:
                         type: string
-                      certificate:
-                        description: |-
-                          certificate provides certificate contents. This should be a single serving certificate, not a certificate
-                          chain. Do not include a CA certificate.
-                        type: string
-                      destinationCACertificate:
-                        description: |-
-                          destinationCACertificate provides the contents of the ca certificate of the final destination.  When using reencrypt
-                          termination this file should be provided in order to have routers use it for health checks on the secure connection.
-                          If this field is not specified, the router may provide its own destination CA and perform hostname validation using
-                          the short service name (service.namespace.svc), which allows infrastructure generated certificates to automatically
-                          verify.
-                        type: string
-                      externalCertificate:
-                        description: |-
-                          externalCertificate provides certificate contents as a secret reference.
-                          This should be a single serving certificate, not a certificate
-                          chain. Do not include a CA certificate. The secret referenced should
-                          be present in the same namespace as that of the Route.
-                          Forbidden when `certificate` is set.
-                          The router service account needs to be granted with read-only access to this secret,
-                          please refer to openshift docs for additional details.
+                      description: Additional annotations that should include f.e. gateway class if using not default gateway controller
+                      type: object
+                    enableGatewayAPIOpenshift:
+                      default: false
+                      description: Switch for enabling Gateway API on Openshift. Default is false.
+                      type: boolean
+                    gatewayClassName:
+                      default: ibm-licensing
+                      description: GatewayClassName defines gateway class name option to be passed to the gateway spec field. Default is ibm-licensing.
+                      type: string
+                    httpsPort:
+                      default: 443
+                      description: HTTPS port for Gateway listener. Default is 443. Only used when TLSSecretName is set.
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    tlsSecretName:
+                      default: ibm-license-service-cert-internal
+                      description: TLS Options to enable secure connection. Default is ibm-license-service-cert-internal.
+                      type: string
+                  type: object
+                httpsCertsSource:
+                  description: 'options: self-signed or custom'
+                  enum:
+                    - self-signed
+                    - custom
+                    - ocp
+                  type: string
+                httpsEnable:
+                  description: Enables https access at pod level, httpsCertsSource needed if true
+                  type: boolean
+                imageName:
+                  description: IBM Licensing Service docker Image Name, will override default value and disable IBM_LICENSING_IMAGE env value in operator deployment
+                  type: string
+                imagePullPolicy:
+                  description: PullPolicy describes a policy for if/when to pull a container image
+                  enum:
+                    - Always
+                    - IfNotPresent
+                    - Never
+                  type: string
+                imagePullSecrets:
+                  description: Array of pull secrets which should include existing at InstanceNamespace secret to allow pulling IBM Licensing image
+                  items:
+                    type: string
+                  type: array
+                imageRegistry:
+                  description: IBM Licensing Service docker Image Registry, will override default value and disable IBM_LICENSING_IMAGE env value in operator deployment
+                  type: string
+                imageTagPostfix:
+                  description: IBM Licensing Service docker Image Tag or Digest, will override default value and disable IBM_LICENSING_IMAGE env value in operator deployment
+                  type: string
+                instanceNamespace:
+                  description: |-
+                    Existing or to be created namespace where application will start. In case metering data collection is used,
+                    should be the same namespace as metering components
+                  type: string
+                labels:
+                  additionalProperties:
+                    type: string
+                  description: Labels to be copied into all relevant resources
+                  type: object
+                license:
+                  description: IBM License Service license acceptance.
+                  properties:
+                    accept:
+                      description: 'By installing the IBM License Service, you accept the license terms for the particular IBM product for which you are deploying this component: ibm.biz/lsvc-lic.'
+                      type: boolean
+                  type: object
+                logLevel:
+                  description: 'Should application pod show additional information, options: DEBUG, INFO, VERBOSE'
+                  enum:
+                    - DEBUG
+                    - INFO
+                    - VERBOSE
+                  type: string
+                resources:
+                  description: ResourceRequirements describes the compute resource requirements.
+                  properties:
+                    claims:
+                      description: |-
+                        Claims lists the names of resources, defined in spec.resourceClaims,
+                        that are used by this container.
+
+                        This field depends on the
+                        DynamicResourceAllocation feature gate.
+
+                        This field is immutable. It can only be set for containers.
+                      items:
+                        description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                         properties:
                           name:
                             description: |-
-                              name of the referent.
-                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              Name must match the name of one entry in pod.spec.resourceClaims of
+                              the Pod where this field is used. It makes that resource available
+                              inside a container.
                             type: string
+                          request:
+                            description: |-
+                              Request is the name chosen for a request in the referenced claim.
+                              If empty, everything from the claim is made available, otherwise
+                              only the result of this request.
+                            type: string
+                        required:
+                          - name
                         type: object
-                        x-kubernetes-map-type: atomic
-                      insecureEdgeTerminationPolicy:
-                        description: |-
-                          insecureEdgeTerminationPolicy indicates the desired behavior for insecure connections to a route. While
-                          each router may make its own decisions on which ports to expose, this is normally port 80.
-
-                          If a route does not specify insecureEdgeTerminationPolicy, then the default behavior is "None".
-
-                          * Allow - traffic is sent to the server on the insecure port (edge/reencrypt terminations only).
-
-                          * None - no traffic is allowed on the insecure port (default).
-
-                          * Redirect - clients are redirected to the secure port.
-                        enum:
-                        - Allow
-                        - None
-                        - Redirect
-                        - ""
-                        type: string
-                      key:
-                        description: key provides key file contents
-                        type: string
-                      termination:
-                        description: |-
-                          termination indicates the TLS termination type.
-
-                          * edge - TLS termination is done by the router and http is used to communicate with the backend (default)
-
-                          * passthrough - Traffic is sent straight to the destination without the router providing TLS termination
-
-                          * reencrypt - TLS termination is done by the router and https is used to communicate with the backend
-
-                          Note: passthrough termination is incompatible with httpHeader actions
-                        enum:
-                        - edge
-                        - reencrypt
-                        - passthrough
-                        type: string
-                    required:
-                    - termination
-                    type: object
-                    x-kubernetes-validations:
-                    - message: 'cannot have both spec.tls.termination: passthrough
-                        and spec.tls.insecureEdgeTerminationPolicy: Allow'
-                      rule: 'has(self.termination) && has(self.insecureEdgeTerminationPolicy)
-                        ? !((self.termination==''passthrough'') && (self.insecureEdgeTerminationPolicy==''Allow''))
-                        : true'
-                type: object
-              securityContext:
-                description: If default SCC user ID fails, you can set runAsUser option
-                  to fix that
-                properties:
-                  runAsUser:
-                    format: int64
-                    type: integer
-                required:
-                - runAsUser
-                type: object
-              sender:
-                description: Sender configuration, set if you have multi-cluster environment
-                  from which you collect data
-                properties:
-                  clusterID:
-                    description: Unique ID of reporting cluster
-                    type: string
-                  clusterName:
-                    description: What is the name of this reporting cluster in multi-cluster
-                      system. If not provided, CLUSTER_ID will be used as CLUSTER_NAME
-                      at Operand level
-                    type: string
-                  frequency:
-                    description: Frequency of workloads scans as cron expression.
-                      If not provided, workloads reporting is disabled.
-                    pattern: (@(annually|yearly|monthly|weekly|daily|midnight|hourly))|((((\d+,)+\d+|(\d+(\/|-)\d+)|\d+|\*)
-                      ?){5,7})
-                    type: string
-                  reporterCertsSecretName:
-                    description: Name of the secret that contains the License Service
-                      Reporter certificate(s) used to establish a secure connection
-                      with it. You need to create it in instance namespace
-                    type: string
-                  reporterSecretToken:
-                    description: License Service Reporter authentication token, provided
-                      by secret that you need to create in instance namespace
-                    type: string
-                  reporterURL:
-                    description: URL for License Service Reporter receiver that collects
-                      and aggregate multi cluster licensing data.
-                    type: string
-                  validateReporterCerts:
-                    description: Enable certificates validation when uploading data
-                      to the License Service Reporter
-                    type: boolean
-                type: object
-              softwareCentral:
-                description: Software Central integration configuration
-                properties:
-                  enable:
-                    description: Enable automatic upload to Software Central
-                    type: boolean
-                  entitlementKeySecret:
-                    description: Name of the Kubernetes secret in ibm-licensing namespace
-                      containing IBM Entitlement Key
-                    type: string
-                  frequency:
-                    description: 'Cron expression for upload schedule (default: "5
-                      0 * * *")'
-                    pattern: (@(annually|yearly|monthly|weekly|daily|midnight|hourly))|((((\d+,)+\d+|(\d+(\/|-)\d+)|\d+|\*)
-                      ?){5,7})
-                    type: string
-                  sandbox:
-                    description: 'Use sandbox environment (default: false)'
-                    type: boolean
-                type: object
-              version:
-                description: Version
-                type: string
-            required:
-            - datasource
-            - httpsEnable
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            description: IBMLicensingStatus defines the observed state of IBMLicensing
-            properties:
-              features:
-                properties:
-                  rhmpEnabled:
-                    type: boolean
-                type: object
-              licensingPods:
-                description: The status of IBM License Service Pods.
-                items:
-                  description: |-
-                    PodStatus represents information about the status of a pod. Status may trail the actual
-                    state of a system, especially if the node that hosts the pod cannot contact the control
-                    plane.
-                  properties:
-                    allocatedResources:
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
+                    limits:
                       additionalProperties:
                         anyOf:
-                        - type: integer
-                        - type: string
+                          - type: integer
+                          - type: string
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       description: |-
-                        AllocatedResources is the total requests allocated for this pod by the node.
-                        If pod-level requests are not set, this will be the total requests aggregated
-                        across containers in the pod.
+                        Limits describes the maximum amount of compute resources allowed.
+                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                       type: object
-                    conditions:
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
                       description: |-
-                        Current service state of pod.
-                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions
-                      items:
-                        description: PodCondition contains details for the current
-                          condition of this pod.
-                        properties:
-                          lastProbeTime:
-                            description: Last time we probed the condition.
-                            format: date-time
-                            type: string
-                          lastTransitionTime:
-                            description: Last time the condition transitioned from
-                              one status to another.
-                            format: date-time
-                            type: string
-                          message:
-                            description: Human-readable message indicating details
-                              about last transition.
-                            type: string
-                          observedGeneration:
-                            description: |-
-                              If set, this represents the .metadata.generation that the pod condition was set based upon.
-                              The PodObservedGenerationTracking feature gate must be enabled to use this field.
-                            format: int64
-                            type: integer
-                          reason:
-                            description: Unique, one-word, CamelCase reason for the
-                              condition's last transition.
-                            type: string
-                          status:
-                            description: |-
-                              Status is the status of the condition.
-                              Can be True, False, Unknown.
-                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions
-                            type: string
-                          type:
-                            description: |-
-                              Type is the type of the condition.
-                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions
-                            type: string
-                        required:
-                        - status
-                        - type
-                        type: object
-                      type: array
-                      x-kubernetes-list-map-keys:
-                      - type
-                      x-kubernetes-list-type: map
-                    containerStatuses:
-                      description: |-
-                        Statuses of containers in this pod.
-                        Each container in the pod should have at most one status in this list,
-                        and all statuses should be for containers in the pod.
-                        However this is not enforced.
-                        If a status for a non-existent container is present in the list, or the list has duplicate names,
-                        the behavior of various Kubernetes components is not defined and those statuses might be
-                        ignored.
-                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status
-                      items:
-                        description: ContainerStatus contains details for the current
-                          status of this container.
-                        properties:
-                          allocatedResources:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: |-
-                              AllocatedResources represents the compute resources allocated for this container by the
-                              node. Kubelet sets this value to Container.Resources.Requests upon successful pod admission
-                              and after successfully admitting desired pod resize.
-                            type: object
-                          allocatedResourcesStatus:
-                            description: |-
-                              AllocatedResourcesStatus represents the status of various resources
-                              allocated for this Pod.
-                            items:
-                              description: ResourceStatus represents the status of
-                                a single resource allocated to a Pod.
-                              properties:
-                                name:
-                                  description: |-
-                                    Name of the resource. Must be unique within the pod and in case of non-DRA resource, match one of the resources from the pod spec.
-                                    For DRA resources, the value must be "claim:<claim_name>/<request>".
-                                    When this status is reported about a container, the "claim_name" and "request" must match one of the claims of this container.
-                                  type: string
-                                resources:
-                                  description: |-
-                                    List of unique resources health. Each element in the list contains an unique resource ID and its health.
-                                    At a minimum, for the lifetime of a Pod, resource ID must uniquely identify the resource allocated to the Pod on the Node.
-                                    If other Pod on the same Node reports the status with the same resource ID, it must be the same resource they share.
-                                    See ResourceID type definition for a specific format it has in various use cases.
-                                  items:
-                                    description: |-
-                                      ResourceHealth represents the health of a resource. It has the latest device health information.
-                                      This is a part of KEP https://kep.k8s.io/4680.
-                                    properties:
-                                      health:
-                                        description: |-
-                                          Health of the resource.
-                                          can be one of:
-                                           - Healthy: operates as normal
-                                           - Unhealthy: reported unhealthy. We consider this a temporary health issue
-                                                        since we do not have a mechanism today to distinguish
-                                                        temporary and permanent issues.
-                                           - Unknown: The status cannot be determined.
-                                                      For example, Device Plugin got unregistered and hasn't been re-registered since.
-
-                                          In future we may want to introduce the PermanentlyUnhealthy Status.
-                                        type: string
-                                      resourceID:
-                                        description: ResourceID is the unique identifier
-                                          of the resource. See the ResourceID type
-                                          for more information.
-                                        type: string
-                                    required:
-                                    - resourceID
-                                    type: object
-                                  type: array
-                                  x-kubernetes-list-map-keys:
-                                  - resourceID
-                                  x-kubernetes-list-type: map
-                              required:
-                              - name
-                              type: object
-                            type: array
-                            x-kubernetes-list-map-keys:
-                            - name
-                            x-kubernetes-list-type: map
-                          containerID:
-                            description: |-
-                              ContainerID is the ID of the container in the format '<type>://<container_id>'.
-                              Where type is a container runtime identifier, returned from Version call of CRI API
-                              (for example "containerd").
-                            type: string
-                          image:
-                            description: |-
-                              Image is the name of container image that the container is running.
-                              The container image may not match the image used in the PodSpec,
-                              as it may have been resolved by the runtime.
-                              More info: https://kubernetes.io/docs/concepts/containers/images.
-                            type: string
-                          imageID:
-                            description: |-
-                              ImageID is the image ID of the container's image. The image ID may not
-                              match the image ID of the image used in the PodSpec, as it may have been
-                              resolved by the runtime.
-                            type: string
-                          lastState:
-                            description: |-
-                              LastTerminationState holds the last termination state of the container to
-                              help debug container crashes and restarts. This field is not
-                              populated if the container is still running and RestartCount is 0.
-                            properties:
-                              running:
-                                description: Details about a running container
-                                properties:
-                                  startedAt:
-                                    description: Time at which the container was last
-                                      (re-)started
-                                    format: date-time
-                                    type: string
-                                type: object
-                              terminated:
-                                description: Details about a terminated container
-                                properties:
-                                  containerID:
-                                    description: Container's ID in the format '<type>://<container_id>'
-                                    type: string
-                                  exitCode:
-                                    description: Exit status from the last termination
-                                      of the container
-                                    format: int32
-                                    type: integer
-                                  finishedAt:
-                                    description: Time at which the container last
-                                      terminated
-                                    format: date-time
-                                    type: string
-                                  message:
-                                    description: Message regarding the last termination
-                                      of the container
-                                    type: string
-                                  reason:
-                                    description: (brief) reason from the last termination
-                                      of the container
-                                    type: string
-                                  signal:
-                                    description: Signal from the last termination
-                                      of the container
-                                    format: int32
-                                    type: integer
-                                  startedAt:
-                                    description: Time at which previous execution
-                                      of the container started
-                                    format: date-time
-                                    type: string
-                                required:
-                                - exitCode
-                                type: object
-                              waiting:
-                                description: Details about a waiting container
-                                properties:
-                                  message:
-                                    description: Message regarding why the container
-                                      is not yet running.
-                                    type: string
-                                  reason:
-                                    description: (brief) reason the container is not
-                                      yet running.
-                                    type: string
-                                type: object
-                            type: object
-                          name:
-                            description: |-
-                              Name is a DNS_LABEL representing the unique name of the container.
-                              Each container in a pod must have a unique name across all container types.
-                              Cannot be updated.
-                            type: string
-                          ready:
-                            description: |-
-                              Ready specifies whether the container is currently passing its readiness check.
-                              The value will change as readiness probes keep executing. If no readiness
-                              probes are specified, this field defaults to true once the container is
-                              fully started (see Started field).
-
-                              The value is typically used to determine whether a container is ready to
-                              accept traffic.
-                            type: boolean
-                          resources:
-                            description: |-
-                              Resources represents the compute resource requests and limits that have been successfully
-                              enacted on the running container after it has been started or has been successfully resized.
-                            properties:
-                              claims:
-                                description: |-
-                                  Claims lists the names of resources, defined in spec.resourceClaims,
-                                  that are used by this container.
-
-                                  This field depends on the
-                                  DynamicResourceAllocation feature gate.
-
-                                  This field is immutable. It can only be set for containers.
-                                items:
-                                  description: ResourceClaim references one entry
-                                    in PodSpec.ResourceClaims.
-                                  properties:
-                                    name:
-                                      description: |-
-                                        Name must match the name of one entry in pod.spec.resourceClaims of
-                                        the Pod where this field is used. It makes that resource available
-                                        inside a container.
-                                      type: string
-                                    request:
-                                      description: |-
-                                        Request is the name chosen for a request in the referenced claim.
-                                        If empty, everything from the claim is made available, otherwise
-                                        only the result of this request.
-                                      type: string
-                                  required:
-                                  - name
-                                  type: object
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                - name
-                                x-kubernetes-list-type: map
-                              limits:
-                                additionalProperties:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                description: |-
-                                  Limits describes the maximum amount of compute resources allowed.
-                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                                type: object
-                              requests:
-                                additionalProperties:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                description: |-
-                                  Requests describes the minimum amount of compute resources required.
-                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                                type: object
-                            type: object
-                          restartCount:
-                            description: |-
-                              RestartCount holds the number of times the container has been restarted.
-                              Kubelet makes an effort to always increment the value, but there
-                              are cases when the state may be lost due to node restarts and then the value
-                              may be reset to 0. The value is never negative.
-                            format: int32
-                            type: integer
-                          started:
-                            description: |-
-                              Started indicates whether the container has finished its postStart lifecycle hook
-                              and passed its startup probe.
-                              Initialized as false, becomes true after startupProbe is considered
-                              successful. Resets to false when the container is restarted, or if kubelet
-                              loses state temporarily. In both cases, startup probes will run again.
-                              Is always true when no startupProbe is defined and container is running and
-                              has passed the postStart lifecycle hook. The null value must be treated the
-                              same as false.
-                            type: boolean
-                          state:
-                            description: State holds details about the container's
-                              current condition.
-                            properties:
-                              running:
-                                description: Details about a running container
-                                properties:
-                                  startedAt:
-                                    description: Time at which the container was last
-                                      (re-)started
-                                    format: date-time
-                                    type: string
-                                type: object
-                              terminated:
-                                description: Details about a terminated container
-                                properties:
-                                  containerID:
-                                    description: Container's ID in the format '<type>://<container_id>'
-                                    type: string
-                                  exitCode:
-                                    description: Exit status from the last termination
-                                      of the container
-                                    format: int32
-                                    type: integer
-                                  finishedAt:
-                                    description: Time at which the container last
-                                      terminated
-                                    format: date-time
-                                    type: string
-                                  message:
-                                    description: Message regarding the last termination
-                                      of the container
-                                    type: string
-                                  reason:
-                                    description: (brief) reason from the last termination
-                                      of the container
-                                    type: string
-                                  signal:
-                                    description: Signal from the last termination
-                                      of the container
-                                    format: int32
-                                    type: integer
-                                  startedAt:
-                                    description: Time at which previous execution
-                                      of the container started
-                                    format: date-time
-                                    type: string
-                                required:
-                                - exitCode
-                                type: object
-                              waiting:
-                                description: Details about a waiting container
-                                properties:
-                                  message:
-                                    description: Message regarding why the container
-                                      is not yet running.
-                                    type: string
-                                  reason:
-                                    description: (brief) reason the container is not
-                                      yet running.
-                                    type: string
-                                type: object
-                            type: object
-                          stopSignal:
-                            description: StopSignal reports the effective stop signal
-                              for this container
-                            type: string
-                          user:
-                            description: User represents user identity information
-                              initially attached to the first process of the container
-                            properties:
-                              linux:
-                                description: |-
-                                  Linux holds user identity information initially attached to the first process of the containers in Linux.
-                                  Note that the actual running identity can be changed if the process has enough privilege to do so.
-                                properties:
-                                  gid:
-                                    description: GID is the primary gid initially
-                                      attached to the first process in the container
-                                    format: int64
-                                    type: integer
-                                  supplementalGroups:
-                                    description: SupplementalGroups are the supplemental
-                                      groups initially attached to the first process
-                                      in the container
-                                    items:
-                                      format: int64
-                                      type: integer
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                  uid:
-                                    description: UID is the primary uid initially
-                                      attached to the first process in the container
-                                    format: int64
-                                    type: integer
-                                required:
-                                - gid
-                                - uid
-                                type: object
-                            type: object
-                          volumeMounts:
-                            description: Status of volume mounts.
-                            items:
-                              description: VolumeMountStatus shows status of volume
-                                mounts.
-                              properties:
-                                mountPath:
-                                  description: MountPath corresponds to the original
-                                    VolumeMount.
-                                  type: string
-                                name:
-                                  description: Name corresponds to the name of the
-                                    original VolumeMount.
-                                  type: string
-                                readOnly:
-                                  description: ReadOnly corresponds to the original
-                                    VolumeMount.
-                                  type: boolean
-                                recursiveReadOnly:
-                                  description: |-
-                                    RecursiveReadOnly must be set to Disabled, Enabled, or unspecified (for non-readonly mounts).
-                                    An IfPossible value in the original VolumeMount must be translated to Disabled or Enabled,
-                                    depending on the mount result.
-                                  type: string
-                              required:
-                              - mountPath
-                              - name
-                              type: object
-                            type: array
-                            x-kubernetes-list-map-keys:
-                            - mountPath
-                            x-kubernetes-list-type: map
-                        required:
-                        - image
-                        - imageID
-                        - name
-                        - ready
-                        - restartCount
-                        type: object
-                      type: array
-                      x-kubernetes-list-type: atomic
-                    ephemeralContainerStatuses:
-                      description: |-
-                        Statuses for any ephemeral containers that have run in this pod.
-                        Each ephemeral container in the pod should have at most one status in this list,
-                        and all statuses should be for containers in the pod.
-                        However this is not enforced.
-                        If a status for a non-existent container is present in the list, or the list has duplicate names,
-                        the behavior of various Kubernetes components is not defined and those statuses might be
-                        ignored.
-                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status
-                      items:
-                        description: ContainerStatus contains details for the current
-                          status of this container.
-                        properties:
-                          allocatedResources:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: |-
-                              AllocatedResources represents the compute resources allocated for this container by the
-                              node. Kubelet sets this value to Container.Resources.Requests upon successful pod admission
-                              and after successfully admitting desired pod resize.
-                            type: object
-                          allocatedResourcesStatus:
-                            description: |-
-                              AllocatedResourcesStatus represents the status of various resources
-                              allocated for this Pod.
-                            items:
-                              description: ResourceStatus represents the status of
-                                a single resource allocated to a Pod.
-                              properties:
-                                name:
-                                  description: |-
-                                    Name of the resource. Must be unique within the pod and in case of non-DRA resource, match one of the resources from the pod spec.
-                                    For DRA resources, the value must be "claim:<claim_name>/<request>".
-                                    When this status is reported about a container, the "claim_name" and "request" must match one of the claims of this container.
-                                  type: string
-                                resources:
-                                  description: |-
-                                    List of unique resources health. Each element in the list contains an unique resource ID and its health.
-                                    At a minimum, for the lifetime of a Pod, resource ID must uniquely identify the resource allocated to the Pod on the Node.
-                                    If other Pod on the same Node reports the status with the same resource ID, it must be the same resource they share.
-                                    See ResourceID type definition for a specific format it has in various use cases.
-                                  items:
-                                    description: |-
-                                      ResourceHealth represents the health of a resource. It has the latest device health information.
-                                      This is a part of KEP https://kep.k8s.io/4680.
-                                    properties:
-                                      health:
-                                        description: |-
-                                          Health of the resource.
-                                          can be one of:
-                                           - Healthy: operates as normal
-                                           - Unhealthy: reported unhealthy. We consider this a temporary health issue
-                                                        since we do not have a mechanism today to distinguish
-                                                        temporary and permanent issues.
-                                           - Unknown: The status cannot be determined.
-                                                      For example, Device Plugin got unregistered and hasn't been re-registered since.
-
-                                          In future we may want to introduce the PermanentlyUnhealthy Status.
-                                        type: string
-                                      resourceID:
-                                        description: ResourceID is the unique identifier
-                                          of the resource. See the ResourceID type
-                                          for more information.
-                                        type: string
-                                    required:
-                                    - resourceID
-                                    type: object
-                                  type: array
-                                  x-kubernetes-list-map-keys:
-                                  - resourceID
-                                  x-kubernetes-list-type: map
-                              required:
-                              - name
-                              type: object
-                            type: array
-                            x-kubernetes-list-map-keys:
-                            - name
-                            x-kubernetes-list-type: map
-                          containerID:
-                            description: |-
-                              ContainerID is the ID of the container in the format '<type>://<container_id>'.
-                              Where type is a container runtime identifier, returned from Version call of CRI API
-                              (for example "containerd").
-                            type: string
-                          image:
-                            description: |-
-                              Image is the name of container image that the container is running.
-                              The container image may not match the image used in the PodSpec,
-                              as it may have been resolved by the runtime.
-                              More info: https://kubernetes.io/docs/concepts/containers/images.
-                            type: string
-                          imageID:
-                            description: |-
-                              ImageID is the image ID of the container's image. The image ID may not
-                              match the image ID of the image used in the PodSpec, as it may have been
-                              resolved by the runtime.
-                            type: string
-                          lastState:
-                            description: |-
-                              LastTerminationState holds the last termination state of the container to
-                              help debug container crashes and restarts. This field is not
-                              populated if the container is still running and RestartCount is 0.
-                            properties:
-                              running:
-                                description: Details about a running container
-                                properties:
-                                  startedAt:
-                                    description: Time at which the container was last
-                                      (re-)started
-                                    format: date-time
-                                    type: string
-                                type: object
-                              terminated:
-                                description: Details about a terminated container
-                                properties:
-                                  containerID:
-                                    description: Container's ID in the format '<type>://<container_id>'
-                                    type: string
-                                  exitCode:
-                                    description: Exit status from the last termination
-                                      of the container
-                                    format: int32
-                                    type: integer
-                                  finishedAt:
-                                    description: Time at which the container last
-                                      terminated
-                                    format: date-time
-                                    type: string
-                                  message:
-                                    description: Message regarding the last termination
-                                      of the container
-                                    type: string
-                                  reason:
-                                    description: (brief) reason from the last termination
-                                      of the container
-                                    type: string
-                                  signal:
-                                    description: Signal from the last termination
-                                      of the container
-                                    format: int32
-                                    type: integer
-                                  startedAt:
-                                    description: Time at which previous execution
-                                      of the container started
-                                    format: date-time
-                                    type: string
-                                required:
-                                - exitCode
-                                type: object
-                              waiting:
-                                description: Details about a waiting container
-                                properties:
-                                  message:
-                                    description: Message regarding why the container
-                                      is not yet running.
-                                    type: string
-                                  reason:
-                                    description: (brief) reason the container is not
-                                      yet running.
-                                    type: string
-                                type: object
-                            type: object
-                          name:
-                            description: |-
-                              Name is a DNS_LABEL representing the unique name of the container.
-                              Each container in a pod must have a unique name across all container types.
-                              Cannot be updated.
-                            type: string
-                          ready:
-                            description: |-
-                              Ready specifies whether the container is currently passing its readiness check.
-                              The value will change as readiness probes keep executing. If no readiness
-                              probes are specified, this field defaults to true once the container is
-                              fully started (see Started field).
-
-                              The value is typically used to determine whether a container is ready to
-                              accept traffic.
-                            type: boolean
-                          resources:
-                            description: |-
-                              Resources represents the compute resource requests and limits that have been successfully
-                              enacted on the running container after it has been started or has been successfully resized.
-                            properties:
-                              claims:
-                                description: |-
-                                  Claims lists the names of resources, defined in spec.resourceClaims,
-                                  that are used by this container.
-
-                                  This field depends on the
-                                  DynamicResourceAllocation feature gate.
-
-                                  This field is immutable. It can only be set for containers.
-                                items:
-                                  description: ResourceClaim references one entry
-                                    in PodSpec.ResourceClaims.
-                                  properties:
-                                    name:
-                                      description: |-
-                                        Name must match the name of one entry in pod.spec.resourceClaims of
-                                        the Pod where this field is used. It makes that resource available
-                                        inside a container.
-                                      type: string
-                                    request:
-                                      description: |-
-                                        Request is the name chosen for a request in the referenced claim.
-                                        If empty, everything from the claim is made available, otherwise
-                                        only the result of this request.
-                                      type: string
-                                  required:
-                                  - name
-                                  type: object
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                - name
-                                x-kubernetes-list-type: map
-                              limits:
-                                additionalProperties:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                description: |-
-                                  Limits describes the maximum amount of compute resources allowed.
-                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                                type: object
-                              requests:
-                                additionalProperties:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                description: |-
-                                  Requests describes the minimum amount of compute resources required.
-                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                                type: object
-                            type: object
-                          restartCount:
-                            description: |-
-                              RestartCount holds the number of times the container has been restarted.
-                              Kubelet makes an effort to always increment the value, but there
-                              are cases when the state may be lost due to node restarts and then the value
-                              may be reset to 0. The value is never negative.
-                            format: int32
-                            type: integer
-                          started:
-                            description: |-
-                              Started indicates whether the container has finished its postStart lifecycle hook
-                              and passed its startup probe.
-                              Initialized as false, becomes true after startupProbe is considered
-                              successful. Resets to false when the container is restarted, or if kubelet
-                              loses state temporarily. In both cases, startup probes will run again.
-                              Is always true when no startupProbe is defined and container is running and
-                              has passed the postStart lifecycle hook. The null value must be treated the
-                              same as false.
-                            type: boolean
-                          state:
-                            description: State holds details about the container's
-                              current condition.
-                            properties:
-                              running:
-                                description: Details about a running container
-                                properties:
-                                  startedAt:
-                                    description: Time at which the container was last
-                                      (re-)started
-                                    format: date-time
-                                    type: string
-                                type: object
-                              terminated:
-                                description: Details about a terminated container
-                                properties:
-                                  containerID:
-                                    description: Container's ID in the format '<type>://<container_id>'
-                                    type: string
-                                  exitCode:
-                                    description: Exit status from the last termination
-                                      of the container
-                                    format: int32
-                                    type: integer
-                                  finishedAt:
-                                    description: Time at which the container last
-                                      terminated
-                                    format: date-time
-                                    type: string
-                                  message:
-                                    description: Message regarding the last termination
-                                      of the container
-                                    type: string
-                                  reason:
-                                    description: (brief) reason from the last termination
-                                      of the container
-                                    type: string
-                                  signal:
-                                    description: Signal from the last termination
-                                      of the container
-                                    format: int32
-                                    type: integer
-                                  startedAt:
-                                    description: Time at which previous execution
-                                      of the container started
-                                    format: date-time
-                                    type: string
-                                required:
-                                - exitCode
-                                type: object
-                              waiting:
-                                description: Details about a waiting container
-                                properties:
-                                  message:
-                                    description: Message regarding why the container
-                                      is not yet running.
-                                    type: string
-                                  reason:
-                                    description: (brief) reason the container is not
-                                      yet running.
-                                    type: string
-                                type: object
-                            type: object
-                          stopSignal:
-                            description: StopSignal reports the effective stop signal
-                              for this container
-                            type: string
-                          user:
-                            description: User represents user identity information
-                              initially attached to the first process of the container
-                            properties:
-                              linux:
-                                description: |-
-                                  Linux holds user identity information initially attached to the first process of the containers in Linux.
-                                  Note that the actual running identity can be changed if the process has enough privilege to do so.
-                                properties:
-                                  gid:
-                                    description: GID is the primary gid initially
-                                      attached to the first process in the container
-                                    format: int64
-                                    type: integer
-                                  supplementalGroups:
-                                    description: SupplementalGroups are the supplemental
-                                      groups initially attached to the first process
-                                      in the container
-                                    items:
-                                      format: int64
-                                      type: integer
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                  uid:
-                                    description: UID is the primary uid initially
-                                      attached to the first process in the container
-                                    format: int64
-                                    type: integer
-                                required:
-                                - gid
-                                - uid
-                                type: object
-                            type: object
-                          volumeMounts:
-                            description: Status of volume mounts.
-                            items:
-                              description: VolumeMountStatus shows status of volume
-                                mounts.
-                              properties:
-                                mountPath:
-                                  description: MountPath corresponds to the original
-                                    VolumeMount.
-                                  type: string
-                                name:
-                                  description: Name corresponds to the name of the
-                                    original VolumeMount.
-                                  type: string
-                                readOnly:
-                                  description: ReadOnly corresponds to the original
-                                    VolumeMount.
-                                  type: boolean
-                                recursiveReadOnly:
-                                  description: |-
-                                    RecursiveReadOnly must be set to Disabled, Enabled, or unspecified (for non-readonly mounts).
-                                    An IfPossible value in the original VolumeMount must be translated to Disabled or Enabled,
-                                    depending on the mount result.
-                                  type: string
-                              required:
-                              - mountPath
-                              - name
-                              type: object
-                            type: array
-                            x-kubernetes-list-map-keys:
-                            - mountPath
-                            x-kubernetes-list-type: map
-                        required:
-                        - image
-                        - imageID
-                        - name
-                        - ready
-                        - restartCount
-                        type: object
-                      type: array
-                      x-kubernetes-list-type: atomic
-                    extendedResourceClaimStatus:
-                      description: Status of extended resource claim backed by DRA.
+                        Requests describes the minimum amount of compute resources required.
+                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                      type: object
+                  type: object
+                rhmpEnabled:
+                  description: Is Red Hat Marketplace enabled
+                  type: boolean
+                routeEnabled:
+                  description: Should Route be created to expose IBM Licensing Service API? (only on OpenShift cluster)
+                  type: boolean
+                routeOptions:
+                  description: Route parameters
+                  properties:
+                    tls:
+                      description: TLSConfig defines config used to secure a route and provide termination
                       properties:
-                        requestMappings:
+                        caCertificate:
+                          description: caCertificate provides the cert authority certificate contents
+                          type: string
+                        certificate:
                           description: |-
-                            RequestMappings identifies the mapping of <container, extended resource backed by DRA> to  device request
-                            in the generated ResourceClaim.
-                          items:
-                            description: |-
-                              ContainerExtendedResourceRequest has the mapping of container name,
-                              extended resource name to the device request name.
-                            properties:
-                              containerName:
-                                description: The name of the container requesting
-                                  resources.
-                                type: string
-                              requestName:
-                                description: The name of the request in the special
-                                  ResourceClaim which corresponds to the extended
-                                  resource.
-                                type: string
-                              resourceName:
-                                description: The name of the extended resource in
-                                  that container which gets backed by DRA.
-                                type: string
-                            required:
-                            - containerName
-                            - requestName
-                            - resourceName
-                            type: object
-                          type: array
-                          x-kubernetes-list-type: atomic
-                        resourceClaimName:
+                            certificate provides certificate contents. This should be a single serving certificate, not a certificate
+                            chain. Do not include a CA certificate.
+                          type: string
+                        destinationCACertificate:
                           description: |-
-                            ResourceClaimName is the name of the ResourceClaim that was
-                            generated for the Pod in the namespace of the Pod.
+                            destinationCACertificate provides the contents of the ca certificate of the final destination.  When using reencrypt
+                            termination this file should be provided in order to have routers use it for health checks on the secure connection.
+                            If this field is not specified, the router may provide its own destination CA and perform hostname validation using
+                            the short service name (service.namespace.svc), which allows infrastructure generated certificates to automatically
+                            verify.
+                          type: string
+                        externalCertificate:
+                          description: |-
+                            externalCertificate provides certificate contents as a secret reference.
+                            This should be a single serving certificate, not a certificate
+                            chain. Do not include a CA certificate. The secret referenced should
+                            be present in the same namespace as that of the Route.
+                            Forbidden when `certificate` is set.
+                            The router service account needs to be granted with read-only access to this secret,
+                            please refer to openshift docs for additional details.
+                          properties:
+                            name:
+                              description: |-
+                                name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        insecureEdgeTerminationPolicy:
+                          description: |-
+                            insecureEdgeTerminationPolicy indicates the desired behavior for insecure connections to a route. While
+                            each router may make its own decisions on which ports to expose, this is normally port 80.
+
+                            If a route does not specify insecureEdgeTerminationPolicy, then the default behavior is "None".
+
+                            * Allow - traffic is sent to the server on the insecure port (edge/reencrypt terminations only).
+
+                            * None - no traffic is allowed on the insecure port (default).
+
+                            * Redirect - clients are redirected to the secure port.
+                          enum:
+                            - Allow
+                            - None
+                            - Redirect
+                            - ""
+                          type: string
+                        key:
+                          description: key provides key file contents
+                          type: string
+                        termination:
+                          description: |-
+                            termination indicates the TLS termination type.
+
+                            * edge - TLS termination is done by the router and http is used to communicate with the backend (default)
+
+                            * passthrough - Traffic is sent straight to the destination without the router providing TLS termination
+
+                            * reencrypt - TLS termination is done by the router and https is used to communicate with the backend
+
+                            Note: passthrough termination is incompatible with httpHeader actions
+                          enum:
+                            - edge
+                            - reencrypt
+                            - passthrough
                           type: string
                       required:
-                      - requestMappings
-                      - resourceClaimName
+                        - termination
                       type: object
-                    hostIP:
-                      description: |-
-                        hostIP holds the IP address of the host to which the pod is assigned. Empty if the pod has not started yet.
-                        A pod can be assigned to a node that has a problem in kubelet which in turns mean that HostIP will
-                        not be updated even if there is a node is assigned to pod
+                      x-kubernetes-validations:
+                        - message: 'cannot have both spec.tls.termination: passthrough and spec.tls.insecureEdgeTerminationPolicy: Allow'
+                          rule: 'has(self.termination) && has(self.insecureEdgeTerminationPolicy) ? !((self.termination==''passthrough'') && (self.insecureEdgeTerminationPolicy==''Allow'')) : true'
+                  type: object
+                securityContext:
+                  description: If default SCC user ID fails, you can set runAsUser option to fix that
+                  properties:
+                    runAsUser:
+                      format: int64
+                      type: integer
+                  required:
+                    - runAsUser
+                  type: object
+                sender:
+                  description: Sender configuration, set if you have multi-cluster environment from which you collect data
+                  properties:
+                    clusterID:
+                      description: Unique ID of reporting cluster
                       type: string
-                    hostIPs:
-                      description: |-
-                        hostIPs holds the IP addresses allocated to the host. If this field is specified, the first entry must
-                        match the hostIP field. This list is empty if the pod has not started yet.
-                        A pod can be assigned to a node that has a problem in kubelet which in turns means that HostIPs will
-                        not be updated even if there is a node is assigned to this pod.
-                      items:
-                        description: HostIP represents a single IP address allocated
-                          to the host.
-                        properties:
-                          ip:
-                            description: IP is the IP address assigned to the host
-                            type: string
-                        required:
-                        - ip
+                    clusterName:
+                      description: What is the name of this reporting cluster in multi-cluster system. If not provided, CLUSTER_ID will be used as CLUSTER_NAME at Operand level
+                      type: string
+                    frequency:
+                      description: Frequency of workloads scans as cron expression. If not provided, workloads reporting is disabled.
+                      pattern: (@(annually|yearly|monthly|weekly|daily|midnight|hourly))|((((\d+,)+\d+|(\d+(\/|-)\d+)|\d+|\*) ?){5,7})
+                      type: string
+                    reporterCertsSecretName:
+                      description: Name of the secret that contains the License Service Reporter certificate(s) used to establish a secure connection with it. You need to create it in instance namespace
+                      type: string
+                    reporterSecretToken:
+                      description: License Service Reporter authentication token, provided by secret that you need to create in instance namespace
+                      type: string
+                    reporterURL:
+                      description: URL for License Service Reporter receiver that collects and aggregate multi cluster licensing data.
+                      type: string
+                    validateReporterCerts:
+                      description: Enable certificates validation when uploading data to the License Service Reporter
+                      type: boolean
+                  type: object
+                softwareCentral:
+                  description: Software Central integration configuration
+                  properties:
+                    enable:
+                      description: Enable automatic upload to Software Central
+                      type: boolean
+                    entitlementKeySecret:
+                      description: Name of the Kubernetes secret in ibm-licensing namespace containing IBM Entitlement Key
+                      type: string
+                    frequency:
+                      description: 'Cron expression for upload schedule (default: "5 0 * * *")'
+                      pattern: (@(annually|yearly|monthly|weekly|daily|midnight|hourly))|((((\d+,)+\d+|(\d+(\/|-)\d+)|\d+|\*) ?){5,7})
+                      type: string
+                    sandbox:
+                      description: 'Use sandbox environment (default: false)'
+                      type: boolean
+                  type: object
+                version:
+                  description: Version
+                  type: string
+              required:
+                - datasource
+                - httpsEnable
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              description: IBMLicensingStatus defines the observed state of IBMLicensing
+              properties:
+                features:
+                  properties:
+                    rhmpEnabled:
+                      type: boolean
+                  type: object
+                licensingPods:
+                  description: The status of IBM License Service Pods.
+                  items:
+                    description: |-
+                      PodStatus represents information about the status of a pod. Status may trail the actual
+                      state of a system, especially if the node that hosts the pod cannot contact the control
+                      plane.
+                    properties:
+                      allocatedResources:
+                        additionalProperties:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          AllocatedResources is the total requests allocated for this pod by the node.
+                          If pod-level requests are not set, this will be the total requests aggregated
+                          across containers in the pod.
                         type: object
-                      type: array
-                      x-kubernetes-list-type: atomic
-                    initContainerStatuses:
-                      description: |-
-                        Statuses of init containers in this pod. The most recent successful non-restartable
-                        init container will have ready = true, the most recently started container will have
-                        startTime set.
-                        Each init container in the pod should have at most one status in this list,
-                        and all statuses should be for containers in the pod.
-                        However this is not enforced.
-                        If a status for a non-existent container is present in the list, or the list has duplicate names,
-                        the behavior of various Kubernetes components is not defined and those statuses might be
-                        ignored.
-                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-and-container-status
-                      items:
-                        description: ContainerStatus contains details for the current
-                          status of this container.
-                        properties:
-                          allocatedResources:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: |-
-                              AllocatedResources represents the compute resources allocated for this container by the
-                              node. Kubelet sets this value to Container.Resources.Requests upon successful pod admission
-                              and after successfully admitting desired pod resize.
-                            type: object
-                          allocatedResourcesStatus:
-                            description: |-
-                              AllocatedResourcesStatus represents the status of various resources
-                              allocated for this Pod.
-                            items:
-                              description: ResourceStatus represents the status of
-                                a single resource allocated to a Pod.
-                              properties:
-                                name:
-                                  description: |-
-                                    Name of the resource. Must be unique within the pod and in case of non-DRA resource, match one of the resources from the pod spec.
-                                    For DRA resources, the value must be "claim:<claim_name>/<request>".
-                                    When this status is reported about a container, the "claim_name" and "request" must match one of the claims of this container.
-                                  type: string
-                                resources:
-                                  description: |-
-                                    List of unique resources health. Each element in the list contains an unique resource ID and its health.
-                                    At a minimum, for the lifetime of a Pod, resource ID must uniquely identify the resource allocated to the Pod on the Node.
-                                    If other Pod on the same Node reports the status with the same resource ID, it must be the same resource they share.
-                                    See ResourceID type definition for a specific format it has in various use cases.
-                                  items:
+                      conditions:
+                        description: |-
+                          Current service state of pod.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions
+                        items:
+                          description: PodCondition contains details for the current condition of this pod.
+                          properties:
+                            lastProbeTime:
+                              description: Last time we probed the condition.
+                              format: date-time
+                              type: string
+                            lastTransitionTime:
+                              description: Last time the condition transitioned from one status to another.
+                              format: date-time
+                              type: string
+                            message:
+                              description: Human-readable message indicating details about last transition.
+                              type: string
+                            observedGeneration:
+                              description: |-
+                                If set, this represents the .metadata.generation that the pod condition was set based upon.
+                                The PodObservedGenerationTracking feature gate must be enabled to use this field.
+                              format: int64
+                              type: integer
+                            reason:
+                              description: Unique, one-word, CamelCase reason for the condition's last transition.
+                              type: string
+                            status:
+                              description: |-
+                                Status is the status of the condition.
+                                Can be True, False, Unknown.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions
+                              type: string
+                            type:
+                              description: |-
+                                Type is the type of the condition.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions
+                              type: string
+                          required:
+                            - status
+                            - type
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - type
+                        x-kubernetes-list-type: map
+                      containerStatuses:
+                        description: |-
+                          Statuses of containers in this pod.
+                          Each container in the pod should have at most one status in this list,
+                          and all statuses should be for containers in the pod.
+                          However this is not enforced.
+                          If a status for a non-existent container is present in the list, or the list has duplicate names,
+                          the behavior of various Kubernetes components is not defined and those statuses might be
+                          ignored.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status
+                        items:
+                          description: ContainerStatus contains details for the current status of this container.
+                          properties:
+                            allocatedResources:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: |-
+                                AllocatedResources represents the compute resources allocated for this container by the
+                                node. Kubelet sets this value to Container.Resources.Requests upon successful pod admission
+                                and after successfully admitting desired pod resize.
+                              type: object
+                            allocatedResourcesStatus:
+                              description: |-
+                                AllocatedResourcesStatus represents the status of various resources
+                                allocated for this Pod.
+                              items:
+                                description: ResourceStatus represents the status of a single resource allocated to a Pod.
+                                properties:
+                                  name:
                                     description: |-
-                                      ResourceHealth represents the health of a resource. It has the latest device health information.
-                                      This is a part of KEP https://kep.k8s.io/4680.
-                                    properties:
-                                      health:
-                                        description: |-
-                                          Health of the resource.
-                                          can be one of:
-                                           - Healthy: operates as normal
-                                           - Unhealthy: reported unhealthy. We consider this a temporary health issue
-                                                        since we do not have a mechanism today to distinguish
-                                                        temporary and permanent issues.
-                                           - Unknown: The status cannot be determined.
-                                                      For example, Device Plugin got unregistered and hasn't been re-registered since.
+                                      Name of the resource. Must be unique within the pod and in case of non-DRA resource, match one of the resources from the pod spec.
+                                      For DRA resources, the value must be "claim:<claim_name>/<request>".
+                                      When this status is reported about a container, the "claim_name" and "request" must match one of the claims of this container.
+                                    type: string
+                                  resources:
+                                    description: |-
+                                      List of unique resources health. Each element in the list contains an unique resource ID and its health.
+                                      At a minimum, for the lifetime of a Pod, resource ID must uniquely identify the resource allocated to the Pod on the Node.
+                                      If other Pod on the same Node reports the status with the same resource ID, it must be the same resource they share.
+                                      See ResourceID type definition for a specific format it has in various use cases.
+                                    items:
+                                      description: |-
+                                        ResourceHealth represents the health of a resource. It has the latest device health information.
+                                        This is a part of KEP https://kep.k8s.io/4680.
+                                      properties:
+                                        health:
+                                          description: |-
+                                            Health of the resource.
+                                            can be one of:
+                                             - Healthy: operates as normal
+                                             - Unhealthy: reported unhealthy. We consider this a temporary health issue
+                                                          since we do not have a mechanism today to distinguish
+                                                          temporary and permanent issues.
+                                             - Unknown: The status cannot be determined.
+                                                        For example, Device Plugin got unregistered and hasn't been re-registered since.
 
-                                          In future we may want to introduce the PermanentlyUnhealthy Status.
+                                            In future we may want to introduce the PermanentlyUnhealthy Status.
+                                          type: string
+                                        resourceID:
+                                          description: ResourceID is the unique identifier of the resource. See the ResourceID type for more information.
+                                          type: string
+                                      required:
+                                        - resourceID
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - resourceID
+                                    x-kubernetes-list-type: map
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            containerID:
+                              description: |-
+                                ContainerID is the ID of the container in the format '<type>://<container_id>'.
+                                Where type is a container runtime identifier, returned from Version call of CRI API
+                                (for example "containerd").
+                              type: string
+                            image:
+                              description: |-
+                                Image is the name of container image that the container is running.
+                                The container image may not match the image used in the PodSpec,
+                                as it may have been resolved by the runtime.
+                                More info: https://kubernetes.io/docs/concepts/containers/images.
+                              type: string
+                            imageID:
+                              description: |-
+                                ImageID is the image ID of the container's image. The image ID may not
+                                match the image ID of the image used in the PodSpec, as it may have been
+                                resolved by the runtime.
+                              type: string
+                            lastState:
+                              description: |-
+                                LastTerminationState holds the last termination state of the container to
+                                help debug container crashes and restarts. This field is not
+                                populated if the container is still running and RestartCount is 0.
+                              properties:
+                                running:
+                                  description: Details about a running container
+                                  properties:
+                                    startedAt:
+                                      description: Time at which the container was last (re-)started
+                                      format: date-time
+                                      type: string
+                                  type: object
+                                terminated:
+                                  description: Details about a terminated container
+                                  properties:
+                                    containerID:
+                                      description: Container's ID in the format '<type>://<container_id>'
+                                      type: string
+                                    exitCode:
+                                      description: Exit status from the last termination of the container
+                                      format: int32
+                                      type: integer
+                                    finishedAt:
+                                      description: Time at which the container last terminated
+                                      format: date-time
+                                      type: string
+                                    message:
+                                      description: Message regarding the last termination of the container
+                                      type: string
+                                    reason:
+                                      description: (brief) reason from the last termination of the container
+                                      type: string
+                                    signal:
+                                      description: Signal from the last termination of the container
+                                      format: int32
+                                      type: integer
+                                    startedAt:
+                                      description: Time at which previous execution of the container started
+                                      format: date-time
+                                      type: string
+                                  required:
+                                    - exitCode
+                                  type: object
+                                waiting:
+                                  description: Details about a waiting container
+                                  properties:
+                                    message:
+                                      description: Message regarding why the container is not yet running.
+                                      type: string
+                                    reason:
+                                      description: (brief) reason the container is not yet running.
+                                      type: string
+                                  type: object
+                              type: object
+                            name:
+                              description: |-
+                                Name is a DNS_LABEL representing the unique name of the container.
+                                Each container in a pod must have a unique name across all container types.
+                                Cannot be updated.
+                              type: string
+                            ready:
+                              description: |-
+                                Ready specifies whether the container is currently passing its readiness check.
+                                The value will change as readiness probes keep executing. If no readiness
+                                probes are specified, this field defaults to true once the container is
+                                fully started (see Started field).
+
+                                The value is typically used to determine whether a container is ready to
+                                accept traffic.
+                              type: boolean
+                            resources:
+                              description: |-
+                                Resources represents the compute resource requests and limits that have been successfully
+                                enacted on the running container after it has been started or has been successfully resized.
+                              properties:
+                                claims:
+                                  description: |-
+                                    Claims lists the names of resources, defined in spec.resourceClaims,
+                                    that are used by this container.
+
+                                    This field depends on the
+                                    DynamicResourceAllocation feature gate.
+
+                                    This field is immutable. It can only be set for containers.
+                                  items:
+                                    description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                    properties:
+                                      name:
+                                        description: |-
+                                          Name must match the name of one entry in pod.spec.resourceClaims of
+                                          the Pod where this field is used. It makes that resource available
+                                          inside a container.
                                         type: string
-                                      resourceID:
-                                        description: ResourceID is the unique identifier
-                                          of the resource. See the ResourceID type
-                                          for more information.
+                                      request:
+                                        description: |-
+                                          Request is the name chosen for a request in the referenced claim.
+                                          If empty, everything from the claim is made available, otherwise
+                                          only the result of this request.
                                         type: string
                                     required:
-                                    - resourceID
+                                      - name
                                     type: object
                                   type: array
                                   x-kubernetes-list-map-keys:
-                                  - resourceID
+                                    - name
                                   x-kubernetes-list-type: map
-                              required:
-                              - name
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Limits describes the maximum amount of compute resources allowed.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Requests describes the minimum amount of compute resources required.
+                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
                               type: object
-                            type: array
-                            x-kubernetes-list-map-keys:
-                            - name
-                            x-kubernetes-list-type: map
-                          containerID:
-                            description: |-
-                              ContainerID is the ID of the container in the format '<type>://<container_id>'.
-                              Where type is a container runtime identifier, returned from Version call of CRI API
-                              (for example "containerd").
-                            type: string
-                          image:
-                            description: |-
-                              Image is the name of container image that the container is running.
-                              The container image may not match the image used in the PodSpec,
-                              as it may have been resolved by the runtime.
-                              More info: https://kubernetes.io/docs/concepts/containers/images.
-                            type: string
-                          imageID:
-                            description: |-
-                              ImageID is the image ID of the container's image. The image ID may not
-                              match the image ID of the image used in the PodSpec, as it may have been
-                              resolved by the runtime.
-                            type: string
-                          lastState:
-                            description: |-
-                              LastTerminationState holds the last termination state of the container to
-                              help debug container crashes and restarts. This field is not
-                              populated if the container is still running and RestartCount is 0.
-                            properties:
-                              running:
-                                description: Details about a running container
-                                properties:
-                                  startedAt:
-                                    description: Time at which the container was last
-                                      (re-)started
-                                    format: date-time
-                                    type: string
-                                type: object
-                              terminated:
-                                description: Details about a terminated container
-                                properties:
-                                  containerID:
-                                    description: Container's ID in the format '<type>://<container_id>'
-                                    type: string
-                                  exitCode:
-                                    description: Exit status from the last termination
-                                      of the container
-                                    format: int32
-                                    type: integer
-                                  finishedAt:
-                                    description: Time at which the container last
-                                      terminated
-                                    format: date-time
-                                    type: string
-                                  message:
-                                    description: Message regarding the last termination
-                                      of the container
-                                    type: string
-                                  reason:
-                                    description: (brief) reason from the last termination
-                                      of the container
-                                    type: string
-                                  signal:
-                                    description: Signal from the last termination
-                                      of the container
-                                    format: int32
-                                    type: integer
-                                  startedAt:
-                                    description: Time at which previous execution
-                                      of the container started
-                                    format: date-time
-                                    type: string
-                                required:
-                                - exitCode
-                                type: object
-                              waiting:
-                                description: Details about a waiting container
-                                properties:
-                                  message:
-                                    description: Message regarding why the container
-                                      is not yet running.
-                                    type: string
-                                  reason:
-                                    description: (brief) reason the container is not
-                                      yet running.
-                                    type: string
-                                type: object
-                            type: object
-                          name:
-                            description: |-
-                              Name is a DNS_LABEL representing the unique name of the container.
-                              Each container in a pod must have a unique name across all container types.
-                              Cannot be updated.
-                            type: string
-                          ready:
-                            description: |-
-                              Ready specifies whether the container is currently passing its readiness check.
-                              The value will change as readiness probes keep executing. If no readiness
-                              probes are specified, this field defaults to true once the container is
-                              fully started (see Started field).
-
-                              The value is typically used to determine whether a container is ready to
-                              accept traffic.
-                            type: boolean
-                          resources:
-                            description: |-
-                              Resources represents the compute resource requests and limits that have been successfully
-                              enacted on the running container after it has been started or has been successfully resized.
-                            properties:
-                              claims:
-                                description: |-
-                                  Claims lists the names of resources, defined in spec.resourceClaims,
-                                  that are used by this container.
-
-                                  This field depends on the
-                                  DynamicResourceAllocation feature gate.
-
-                                  This field is immutable. It can only be set for containers.
-                                items:
-                                  description: ResourceClaim references one entry
-                                    in PodSpec.ResourceClaims.
+                            restartCount:
+                              description: |-
+                                RestartCount holds the number of times the container has been restarted.
+                                Kubelet makes an effort to always increment the value, but there
+                                are cases when the state may be lost due to node restarts and then the value
+                                may be reset to 0. The value is never negative.
+                              format: int32
+                              type: integer
+                            started:
+                              description: |-
+                                Started indicates whether the container has finished its postStart lifecycle hook
+                                and passed its startup probe.
+                                Initialized as false, becomes true after startupProbe is considered
+                                successful. Resets to false when the container is restarted, or if kubelet
+                                loses state temporarily. In both cases, startup probes will run again.
+                                Is always true when no startupProbe is defined and container is running and
+                                has passed the postStart lifecycle hook. The null value must be treated the
+                                same as false.
+                              type: boolean
+                            state:
+                              description: State holds details about the container's current condition.
+                              properties:
+                                running:
+                                  description: Details about a running container
                                   properties:
-                                    name:
-                                      description: |-
-                                        Name must match the name of one entry in pod.spec.resourceClaims of
-                                        the Pod where this field is used. It makes that resource available
-                                        inside a container.
+                                    startedAt:
+                                      description: Time at which the container was last (re-)started
+                                      format: date-time
                                       type: string
-                                    request:
-                                      description: |-
-                                        Request is the name chosen for a request in the referenced claim.
-                                        If empty, everything from the claim is made available, otherwise
-                                        only the result of this request.
+                                  type: object
+                                terminated:
+                                  description: Details about a terminated container
+                                  properties:
+                                    containerID:
+                                      description: Container's ID in the format '<type>://<container_id>'
+                                      type: string
+                                    exitCode:
+                                      description: Exit status from the last termination of the container
+                                      format: int32
+                                      type: integer
+                                    finishedAt:
+                                      description: Time at which the container last terminated
+                                      format: date-time
+                                      type: string
+                                    message:
+                                      description: Message regarding the last termination of the container
+                                      type: string
+                                    reason:
+                                      description: (brief) reason from the last termination of the container
+                                      type: string
+                                    signal:
+                                      description: Signal from the last termination of the container
+                                      format: int32
+                                      type: integer
+                                    startedAt:
+                                      description: Time at which previous execution of the container started
+                                      format: date-time
                                       type: string
                                   required:
-                                  - name
+                                    - exitCode
                                   type: object
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                - name
-                                x-kubernetes-list-type: map
-                              limits:
-                                additionalProperties:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                description: |-
-                                  Limits describes the maximum amount of compute resources allowed.
-                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                                type: object
-                              requests:
-                                additionalProperties:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                description: |-
-                                  Requests describes the minimum amount of compute resources required.
-                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                                type: object
-                            type: object
-                          restartCount:
-                            description: |-
-                              RestartCount holds the number of times the container has been restarted.
-                              Kubelet makes an effort to always increment the value, but there
-                              are cases when the state may be lost due to node restarts and then the value
-                              may be reset to 0. The value is never negative.
-                            format: int32
-                            type: integer
-                          started:
-                            description: |-
-                              Started indicates whether the container has finished its postStart lifecycle hook
-                              and passed its startup probe.
-                              Initialized as false, becomes true after startupProbe is considered
-                              successful. Resets to false when the container is restarted, or if kubelet
-                              loses state temporarily. In both cases, startup probes will run again.
-                              Is always true when no startupProbe is defined and container is running and
-                              has passed the postStart lifecycle hook. The null value must be treated the
-                              same as false.
-                            type: boolean
-                          state:
-                            description: State holds details about the container's
-                              current condition.
-                            properties:
-                              running:
-                                description: Details about a running container
-                                properties:
-                                  startedAt:
-                                    description: Time at which the container was last
-                                      (re-)started
-                                    format: date-time
-                                    type: string
-                                type: object
-                              terminated:
-                                description: Details about a terminated container
-                                properties:
-                                  containerID:
-                                    description: Container's ID in the format '<type>://<container_id>'
-                                    type: string
-                                  exitCode:
-                                    description: Exit status from the last termination
-                                      of the container
-                                    format: int32
-                                    type: integer
-                                  finishedAt:
-                                    description: Time at which the container last
-                                      terminated
-                                    format: date-time
-                                    type: string
-                                  message:
-                                    description: Message regarding the last termination
-                                      of the container
-                                    type: string
-                                  reason:
-                                    description: (brief) reason from the last termination
-                                      of the container
-                                    type: string
-                                  signal:
-                                    description: Signal from the last termination
-                                      of the container
-                                    format: int32
-                                    type: integer
-                                  startedAt:
-                                    description: Time at which previous execution
-                                      of the container started
-                                    format: date-time
-                                    type: string
-                                required:
-                                - exitCode
-                                type: object
-                              waiting:
-                                description: Details about a waiting container
-                                properties:
-                                  message:
-                                    description: Message regarding why the container
-                                      is not yet running.
-                                    type: string
-                                  reason:
-                                    description: (brief) reason the container is not
-                                      yet running.
-                                    type: string
-                                type: object
-                            type: object
-                          stopSignal:
-                            description: StopSignal reports the effective stop signal
-                              for this container
-                            type: string
-                          user:
-                            description: User represents user identity information
-                              initially attached to the first process of the container
-                            properties:
-                              linux:
-                                description: |-
-                                  Linux holds user identity information initially attached to the first process of the containers in Linux.
-                                  Note that the actual running identity can be changed if the process has enough privilege to do so.
-                                properties:
-                                  gid:
-                                    description: GID is the primary gid initially
-                                      attached to the first process in the container
-                                    format: int64
-                                    type: integer
-                                  supplementalGroups:
-                                    description: SupplementalGroups are the supplemental
-                                      groups initially attached to the first process
-                                      in the container
-                                    items:
+                                waiting:
+                                  description: Details about a waiting container
+                                  properties:
+                                    message:
+                                      description: Message regarding why the container is not yet running.
+                                      type: string
+                                    reason:
+                                      description: (brief) reason the container is not yet running.
+                                      type: string
+                                  type: object
+                              type: object
+                            stopSignal:
+                              description: StopSignal reports the effective stop signal for this container
+                              type: string
+                            user:
+                              description: User represents user identity information initially attached to the first process of the container
+                              properties:
+                                linux:
+                                  description: |-
+                                    Linux holds user identity information initially attached to the first process of the containers in Linux.
+                                    Note that the actual running identity can be changed if the process has enough privilege to do so.
+                                  properties:
+                                    gid:
+                                      description: GID is the primary gid initially attached to the first process in the container
                                       format: int64
                                       type: integer
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                  uid:
-                                    description: UID is the primary uid initially
-                                      attached to the first process in the container
-                                    format: int64
-                                    type: integer
+                                    supplementalGroups:
+                                      description: SupplementalGroups are the supplemental groups initially attached to the first process in the container
+                                      items:
+                                        format: int64
+                                        type: integer
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    uid:
+                                      description: UID is the primary uid initially attached to the first process in the container
+                                      format: int64
+                                      type: integer
+                                  required:
+                                    - gid
+                                    - uid
+                                  type: object
+                              type: object
+                            volumeMounts:
+                              description: Status of volume mounts.
+                              items:
+                                description: VolumeMountStatus shows status of volume mounts.
+                                properties:
+                                  mountPath:
+                                    description: MountPath corresponds to the original VolumeMount.
+                                    type: string
+                                  name:
+                                    description: Name corresponds to the name of the original VolumeMount.
+                                    type: string
+                                  readOnly:
+                                    description: ReadOnly corresponds to the original VolumeMount.
+                                    type: boolean
+                                  recursiveReadOnly:
+                                    description: |-
+                                      RecursiveReadOnly must be set to Disabled, Enabled, or unspecified (for non-readonly mounts).
+                                      An IfPossible value in the original VolumeMount must be translated to Disabled or Enabled,
+                                      depending on the mount result.
+                                    type: string
                                 required:
-                                - gid
-                                - uid
+                                  - mountPath
+                                  - name
                                 type: object
-                            type: object
-                          volumeMounts:
-                            description: Status of volume mounts.
-                            items:
-                              description: VolumeMountStatus shows status of volume
-                                mounts.
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - mountPath
+                              x-kubernetes-list-type: map
+                          required:
+                            - image
+                            - imageID
+                            - name
+                            - ready
+                            - restartCount
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      ephemeralContainerStatuses:
+                        description: |-
+                          Statuses for any ephemeral containers that have run in this pod.
+                          Each ephemeral container in the pod should have at most one status in this list,
+                          and all statuses should be for containers in the pod.
+                          However this is not enforced.
+                          If a status for a non-existent container is present in the list, or the list has duplicate names,
+                          the behavior of various Kubernetes components is not defined and those statuses might be
+                          ignored.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status
+                        items:
+                          description: ContainerStatus contains details for the current status of this container.
+                          properties:
+                            allocatedResources:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: |-
+                                AllocatedResources represents the compute resources allocated for this container by the
+                                node. Kubelet sets this value to Container.Resources.Requests upon successful pod admission
+                                and after successfully admitting desired pod resize.
+                              type: object
+                            allocatedResourcesStatus:
+                              description: |-
+                                AllocatedResourcesStatus represents the status of various resources
+                                allocated for this Pod.
+                              items:
+                                description: ResourceStatus represents the status of a single resource allocated to a Pod.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name of the resource. Must be unique within the pod and in case of non-DRA resource, match one of the resources from the pod spec.
+                                      For DRA resources, the value must be "claim:<claim_name>/<request>".
+                                      When this status is reported about a container, the "claim_name" and "request" must match one of the claims of this container.
+                                    type: string
+                                  resources:
+                                    description: |-
+                                      List of unique resources health. Each element in the list contains an unique resource ID and its health.
+                                      At a minimum, for the lifetime of a Pod, resource ID must uniquely identify the resource allocated to the Pod on the Node.
+                                      If other Pod on the same Node reports the status with the same resource ID, it must be the same resource they share.
+                                      See ResourceID type definition for a specific format it has in various use cases.
+                                    items:
+                                      description: |-
+                                        ResourceHealth represents the health of a resource. It has the latest device health information.
+                                        This is a part of KEP https://kep.k8s.io/4680.
+                                      properties:
+                                        health:
+                                          description: |-
+                                            Health of the resource.
+                                            can be one of:
+                                             - Healthy: operates as normal
+                                             - Unhealthy: reported unhealthy. We consider this a temporary health issue
+                                                          since we do not have a mechanism today to distinguish
+                                                          temporary and permanent issues.
+                                             - Unknown: The status cannot be determined.
+                                                        For example, Device Plugin got unregistered and hasn't been re-registered since.
+
+                                            In future we may want to introduce the PermanentlyUnhealthy Status.
+                                          type: string
+                                        resourceID:
+                                          description: ResourceID is the unique identifier of the resource. See the ResourceID type for more information.
+                                          type: string
+                                      required:
+                                        - resourceID
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - resourceID
+                                    x-kubernetes-list-type: map
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            containerID:
+                              description: |-
+                                ContainerID is the ID of the container in the format '<type>://<container_id>'.
+                                Where type is a container runtime identifier, returned from Version call of CRI API
+                                (for example "containerd").
+                              type: string
+                            image:
+                              description: |-
+                                Image is the name of container image that the container is running.
+                                The container image may not match the image used in the PodSpec,
+                                as it may have been resolved by the runtime.
+                                More info: https://kubernetes.io/docs/concepts/containers/images.
+                              type: string
+                            imageID:
+                              description: |-
+                                ImageID is the image ID of the container's image. The image ID may not
+                                match the image ID of the image used in the PodSpec, as it may have been
+                                resolved by the runtime.
+                              type: string
+                            lastState:
+                              description: |-
+                                LastTerminationState holds the last termination state of the container to
+                                help debug container crashes and restarts. This field is not
+                                populated if the container is still running and RestartCount is 0.
                               properties:
-                                mountPath:
-                                  description: MountPath corresponds to the original
-                                    VolumeMount.
-                                  type: string
-                                name:
-                                  description: Name corresponds to the name of the
-                                    original VolumeMount.
-                                  type: string
-                                readOnly:
-                                  description: ReadOnly corresponds to the original
-                                    VolumeMount.
-                                  type: boolean
-                                recursiveReadOnly:
+                                running:
+                                  description: Details about a running container
+                                  properties:
+                                    startedAt:
+                                      description: Time at which the container was last (re-)started
+                                      format: date-time
+                                      type: string
+                                  type: object
+                                terminated:
+                                  description: Details about a terminated container
+                                  properties:
+                                    containerID:
+                                      description: Container's ID in the format '<type>://<container_id>'
+                                      type: string
+                                    exitCode:
+                                      description: Exit status from the last termination of the container
+                                      format: int32
+                                      type: integer
+                                    finishedAt:
+                                      description: Time at which the container last terminated
+                                      format: date-time
+                                      type: string
+                                    message:
+                                      description: Message regarding the last termination of the container
+                                      type: string
+                                    reason:
+                                      description: (brief) reason from the last termination of the container
+                                      type: string
+                                    signal:
+                                      description: Signal from the last termination of the container
+                                      format: int32
+                                      type: integer
+                                    startedAt:
+                                      description: Time at which previous execution of the container started
+                                      format: date-time
+                                      type: string
+                                  required:
+                                    - exitCode
+                                  type: object
+                                waiting:
+                                  description: Details about a waiting container
+                                  properties:
+                                    message:
+                                      description: Message regarding why the container is not yet running.
+                                      type: string
+                                    reason:
+                                      description: (brief) reason the container is not yet running.
+                                      type: string
+                                  type: object
+                              type: object
+                            name:
+                              description: |-
+                                Name is a DNS_LABEL representing the unique name of the container.
+                                Each container in a pod must have a unique name across all container types.
+                                Cannot be updated.
+                              type: string
+                            ready:
+                              description: |-
+                                Ready specifies whether the container is currently passing its readiness check.
+                                The value will change as readiness probes keep executing. If no readiness
+                                probes are specified, this field defaults to true once the container is
+                                fully started (see Started field).
+
+                                The value is typically used to determine whether a container is ready to
+                                accept traffic.
+                              type: boolean
+                            resources:
+                              description: |-
+                                Resources represents the compute resource requests and limits that have been successfully
+                                enacted on the running container after it has been started or has been successfully resized.
+                              properties:
+                                claims:
                                   description: |-
-                                    RecursiveReadOnly must be set to Disabled, Enabled, or unspecified (for non-readonly mounts).
-                                    An IfPossible value in the original VolumeMount must be translated to Disabled or Enabled,
-                                    depending on the mount result.
+                                    Claims lists the names of resources, defined in spec.resourceClaims,
+                                    that are used by this container.
+
+                                    This field depends on the
+                                    DynamicResourceAllocation feature gate.
+
+                                    This field is immutable. It can only be set for containers.
+                                  items:
+                                    description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                    properties:
+                                      name:
+                                        description: |-
+                                          Name must match the name of one entry in pod.spec.resourceClaims of
+                                          the Pod where this field is used. It makes that resource available
+                                          inside a container.
+                                        type: string
+                                      request:
+                                        description: |-
+                                          Request is the name chosen for a request in the referenced claim.
+                                          If empty, everything from the claim is made available, otherwise
+                                          only the result of this request.
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Limits describes the maximum amount of compute resources allowed.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Requests describes the minimum amount of compute resources required.
+                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                              type: object
+                            restartCount:
+                              description: |-
+                                RestartCount holds the number of times the container has been restarted.
+                                Kubelet makes an effort to always increment the value, but there
+                                are cases when the state may be lost due to node restarts and then the value
+                                may be reset to 0. The value is never negative.
+                              format: int32
+                              type: integer
+                            started:
+                              description: |-
+                                Started indicates whether the container has finished its postStart lifecycle hook
+                                and passed its startup probe.
+                                Initialized as false, becomes true after startupProbe is considered
+                                successful. Resets to false when the container is restarted, or if kubelet
+                                loses state temporarily. In both cases, startup probes will run again.
+                                Is always true when no startupProbe is defined and container is running and
+                                has passed the postStart lifecycle hook. The null value must be treated the
+                                same as false.
+                              type: boolean
+                            state:
+                              description: State holds details about the container's current condition.
+                              properties:
+                                running:
+                                  description: Details about a running container
+                                  properties:
+                                    startedAt:
+                                      description: Time at which the container was last (re-)started
+                                      format: date-time
+                                      type: string
+                                  type: object
+                                terminated:
+                                  description: Details about a terminated container
+                                  properties:
+                                    containerID:
+                                      description: Container's ID in the format '<type>://<container_id>'
+                                      type: string
+                                    exitCode:
+                                      description: Exit status from the last termination of the container
+                                      format: int32
+                                      type: integer
+                                    finishedAt:
+                                      description: Time at which the container last terminated
+                                      format: date-time
+                                      type: string
+                                    message:
+                                      description: Message regarding the last termination of the container
+                                      type: string
+                                    reason:
+                                      description: (brief) reason from the last termination of the container
+                                      type: string
+                                    signal:
+                                      description: Signal from the last termination of the container
+                                      format: int32
+                                      type: integer
+                                    startedAt:
+                                      description: Time at which previous execution of the container started
+                                      format: date-time
+                                      type: string
+                                  required:
+                                    - exitCode
+                                  type: object
+                                waiting:
+                                  description: Details about a waiting container
+                                  properties:
+                                    message:
+                                      description: Message regarding why the container is not yet running.
+                                      type: string
+                                    reason:
+                                      description: (brief) reason the container is not yet running.
+                                      type: string
+                                  type: object
+                              type: object
+                            stopSignal:
+                              description: StopSignal reports the effective stop signal for this container
+                              type: string
+                            user:
+                              description: User represents user identity information initially attached to the first process of the container
+                              properties:
+                                linux:
+                                  description: |-
+                                    Linux holds user identity information initially attached to the first process of the containers in Linux.
+                                    Note that the actual running identity can be changed if the process has enough privilege to do so.
+                                  properties:
+                                    gid:
+                                      description: GID is the primary gid initially attached to the first process in the container
+                                      format: int64
+                                      type: integer
+                                    supplementalGroups:
+                                      description: SupplementalGroups are the supplemental groups initially attached to the first process in the container
+                                      items:
+                                        format: int64
+                                        type: integer
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    uid:
+                                      description: UID is the primary uid initially attached to the first process in the container
+                                      format: int64
+                                      type: integer
+                                  required:
+                                    - gid
+                                    - uid
+                                  type: object
+                              type: object
+                            volumeMounts:
+                              description: Status of volume mounts.
+                              items:
+                                description: VolumeMountStatus shows status of volume mounts.
+                                properties:
+                                  mountPath:
+                                    description: MountPath corresponds to the original VolumeMount.
+                                    type: string
+                                  name:
+                                    description: Name corresponds to the name of the original VolumeMount.
+                                    type: string
+                                  readOnly:
+                                    description: ReadOnly corresponds to the original VolumeMount.
+                                    type: boolean
+                                  recursiveReadOnly:
+                                    description: |-
+                                      RecursiveReadOnly must be set to Disabled, Enabled, or unspecified (for non-readonly mounts).
+                                      An IfPossible value in the original VolumeMount must be translated to Disabled or Enabled,
+                                      depending on the mount result.
+                                    type: string
+                                required:
+                                  - mountPath
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - mountPath
+                              x-kubernetes-list-type: map
+                          required:
+                            - image
+                            - imageID
+                            - name
+                            - ready
+                            - restartCount
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      extendedResourceClaimStatus:
+                        description: Status of extended resource claim backed by DRA.
+                        properties:
+                          requestMappings:
+                            description: |-
+                              RequestMappings identifies the mapping of <container, extended resource backed by DRA> to  device request
+                              in the generated ResourceClaim.
+                            items:
+                              description: |-
+                                ContainerExtendedResourceRequest has the mapping of container name,
+                                extended resource name to the device request name.
+                              properties:
+                                containerName:
+                                  description: The name of the container requesting resources.
+                                  type: string
+                                requestName:
+                                  description: The name of the request in the special ResourceClaim which corresponds to the extended resource.
+                                  type: string
+                                resourceName:
+                                  description: The name of the extended resource in that container which gets backed by DRA.
                                   type: string
                               required:
-                              - mountPath
-                              - name
+                                - containerName
+                                - requestName
+                                - resourceName
                               type: object
                             type: array
-                            x-kubernetes-list-map-keys:
-                            - mountPath
-                            x-kubernetes-list-type: map
-                        required:
-                        - image
-                        - imageID
-                        - name
-                        - ready
-                        - restartCount
-                        type: object
-                      type: array
-                      x-kubernetes-list-type: atomic
-                    message:
-                      description: A human readable message indicating details about
-                        why the pod is in this condition.
-                      type: string
-                    nominatedNodeName:
-                      description: |-
-                        nominatedNodeName is set only when this pod preempts other pods on the node, but it cannot be
-                        scheduled right away as preemption victims receive their graceful termination periods.
-                        This field does not guarantee that the pod will be scheduled on this node. Scheduler may decide
-                        to place the pod elsewhere if other nodes become available sooner. Scheduler may also decide to
-                        give the resources on this node to a higher priority pod that is created after preemption.
-                        As a result, this field may be different than PodSpec.nodeName when the pod is
-                        scheduled.
-                      type: string
-                    observedGeneration:
-                      description: |-
-                        If set, this represents the .metadata.generation that the pod status was set based upon.
-                        The PodObservedGenerationTracking feature gate must be enabled to use this field.
-                      format: int64
-                      type: integer
-                    phase:
-                      description: |-
-                        The phase of a Pod is a simple, high-level summary of where the Pod is in its lifecycle.
-                        The conditions array, the reason and message fields, and the individual container status
-                        arrays contain more detail about the pod's status.
-                        There are five possible phase values:
-
-                        Pending: The pod has been accepted by the Kubernetes system, but one or more of the
-                        container images has not been created. This includes time before being scheduled as
-                        well as time spent downloading images over the network, which could take a while.
-                        Running: The pod has been bound to a node, and all of the containers have been created.
-                        At least one container is still running, or is in the process of starting or restarting.
-                        Succeeded: All containers in the pod have terminated in success, and will not be restarted.
-                        Failed: All containers in the pod have terminated, and at least one container has
-                        terminated in failure. The container either exited with non-zero status or was terminated
-                        by the system.
-                        Unknown: For some reason the state of the pod could not be obtained, typically due to an
-                        error in communicating with the host of the pod.
-
-                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-phase
-                      type: string
-                    podIP:
-                      description: |-
-                        podIP address allocated to the pod. Routable at least within the cluster.
-                        Empty if not yet allocated.
-                      type: string
-                    podIPs:
-                      description: |-
-                        podIPs holds the IP addresses allocated to the pod. If this field is specified, the 0th entry must
-                        match the podIP field. Pods may be allocated at most 1 value for each of IPv4 and IPv6. This list
-                        is empty if no IPs have been allocated yet.
-                      items:
-                        description: PodIP represents a single IP address allocated
-                          to the pod.
-                        properties:
-                          ip:
-                            description: IP is the IP address assigned to the pod
-                            type: string
-                        required:
-                        - ip
-                        type: object
-                      type: array
-                      x-kubernetes-list-map-keys:
-                      - ip
-                      x-kubernetes-list-type: map
-                    qosClass:
-                      description: |-
-                        The Quality of Service (QOS) classification assigned to the pod based on resource requirements
-                        See PodQOSClass type for available QOS classes
-                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/#quality-of-service-classes
-                      type: string
-                    reason:
-                      description: |-
-                        A brief CamelCase message indicating details about why the pod is in this state.
-                        e.g. 'Evicted'
-                      type: string
-                    resize:
-                      description: |-
-                        Status of resources resize desired for pod's containers.
-                        It is empty if no resources resize is pending.
-                        Any changes to container resources will automatically set this to "Proposed"
-                        Deprecated: Resize status is moved to two pod conditions PodResizePending and PodResizeInProgress.
-                        PodResizePending will track states where the spec has been resized, but the Kubelet has not yet allocated the resources.
-                        PodResizeInProgress will track in-progress resizes, and should be present whenever allocated resources != acknowledged resources.
-                      type: string
-                    resourceClaimStatuses:
-                      description: Status of resource claims.
-                      items:
-                        description: |-
-                          PodResourceClaimStatus is stored in the PodStatus for each PodResourceClaim
-                          which references a ResourceClaimTemplate. It stores the generated name for
-                          the corresponding ResourceClaim.
-                        properties:
-                          name:
-                            description: |-
-                              Name uniquely identifies this resource claim inside the pod.
-                              This must match the name of an entry in pod.spec.resourceClaims,
-                              which implies that the string must be a DNS_LABEL.
-                            type: string
+                            x-kubernetes-list-type: atomic
                           resourceClaimName:
                             description: |-
                               ResourceClaimName is the name of the ResourceClaim that was
-                              generated for the Pod in the namespace of the Pod. If this is
-                              unset, then generating a ResourceClaim was not necessary. The
-                              pod.spec.resourceClaims entry can be ignored in this case.
+                              generated for the Pod in the namespace of the Pod.
                             type: string
                         required:
-                        - name
+                          - requestMappings
+                          - resourceClaimName
                         type: object
-                      type: array
-                      x-kubernetes-list-map-keys:
-                      - name
-                      x-kubernetes-list-type: map
-                    resources:
-                      description: |-
-                        Resources represents the compute resource requests and limits that have been
-                        applied at the pod level if pod-level requests or limits are set in
-                        PodSpec.Resources
-                      properties:
-                        claims:
-                          description: |-
-                            Claims lists the names of resources, defined in spec.resourceClaims,
-                            that are used by this container.
+                      hostIP:
+                        description: |-
+                          hostIP holds the IP address of the host to which the pod is assigned. Empty if the pod has not started yet.
+                          A pod can be assigned to a node that has a problem in kubelet which in turns mean that HostIP will
+                          not be updated even if there is a node is assigned to pod
+                        type: string
+                      hostIPs:
+                        description: |-
+                          hostIPs holds the IP addresses allocated to the host. If this field is specified, the first entry must
+                          match the hostIP field. This list is empty if the pod has not started yet.
+                          A pod can be assigned to a node that has a problem in kubelet which in turns means that HostIPs will
+                          not be updated even if there is a node is assigned to this pod.
+                        items:
+                          description: HostIP represents a single IP address allocated to the host.
+                          properties:
+                            ip:
+                              description: IP is the IP address assigned to the host
+                              type: string
+                          required:
+                            - ip
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      initContainerStatuses:
+                        description: |-
+                          Statuses of init containers in this pod. The most recent successful non-restartable
+                          init container will have ready = true, the most recently started container will have
+                          startTime set.
+                          Each init container in the pod should have at most one status in this list,
+                          and all statuses should be for containers in the pod.
+                          However this is not enforced.
+                          If a status for a non-existent container is present in the list, or the list has duplicate names,
+                          the behavior of various Kubernetes components is not defined and those statuses might be
+                          ignored.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-and-container-status
+                        items:
+                          description: ContainerStatus contains details for the current status of this container.
+                          properties:
+                            allocatedResources:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: |-
+                                AllocatedResources represents the compute resources allocated for this container by the
+                                node. Kubelet sets this value to Container.Resources.Requests upon successful pod admission
+                                and after successfully admitting desired pod resize.
+                              type: object
+                            allocatedResourcesStatus:
+                              description: |-
+                                AllocatedResourcesStatus represents the status of various resources
+                                allocated for this Pod.
+                              items:
+                                description: ResourceStatus represents the status of a single resource allocated to a Pod.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name of the resource. Must be unique within the pod and in case of non-DRA resource, match one of the resources from the pod spec.
+                                      For DRA resources, the value must be "claim:<claim_name>/<request>".
+                                      When this status is reported about a container, the "claim_name" and "request" must match one of the claims of this container.
+                                    type: string
+                                  resources:
+                                    description: |-
+                                      List of unique resources health. Each element in the list contains an unique resource ID and its health.
+                                      At a minimum, for the lifetime of a Pod, resource ID must uniquely identify the resource allocated to the Pod on the Node.
+                                      If other Pod on the same Node reports the status with the same resource ID, it must be the same resource they share.
+                                      See ResourceID type definition for a specific format it has in various use cases.
+                                    items:
+                                      description: |-
+                                        ResourceHealth represents the health of a resource. It has the latest device health information.
+                                        This is a part of KEP https://kep.k8s.io/4680.
+                                      properties:
+                                        health:
+                                          description: |-
+                                            Health of the resource.
+                                            can be one of:
+                                             - Healthy: operates as normal
+                                             - Unhealthy: reported unhealthy. We consider this a temporary health issue
+                                                          since we do not have a mechanism today to distinguish
+                                                          temporary and permanent issues.
+                                             - Unknown: The status cannot be determined.
+                                                        For example, Device Plugin got unregistered and hasn't been re-registered since.
 
-                            This field depends on the
-                            DynamicResourceAllocation feature gate.
+                                            In future we may want to introduce the PermanentlyUnhealthy Status.
+                                          type: string
+                                        resourceID:
+                                          description: ResourceID is the unique identifier of the resource. See the ResourceID type for more information.
+                                          type: string
+                                      required:
+                                        - resourceID
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - resourceID
+                                    x-kubernetes-list-type: map
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            containerID:
+                              description: |-
+                                ContainerID is the ID of the container in the format '<type>://<container_id>'.
+                                Where type is a container runtime identifier, returned from Version call of CRI API
+                                (for example "containerd").
+                              type: string
+                            image:
+                              description: |-
+                                Image is the name of container image that the container is running.
+                                The container image may not match the image used in the PodSpec,
+                                as it may have been resolved by the runtime.
+                                More info: https://kubernetes.io/docs/concepts/containers/images.
+                              type: string
+                            imageID:
+                              description: |-
+                                ImageID is the image ID of the container's image. The image ID may not
+                                match the image ID of the image used in the PodSpec, as it may have been
+                                resolved by the runtime.
+                              type: string
+                            lastState:
+                              description: |-
+                                LastTerminationState holds the last termination state of the container to
+                                help debug container crashes and restarts. This field is not
+                                populated if the container is still running and RestartCount is 0.
+                              properties:
+                                running:
+                                  description: Details about a running container
+                                  properties:
+                                    startedAt:
+                                      description: Time at which the container was last (re-)started
+                                      format: date-time
+                                      type: string
+                                  type: object
+                                terminated:
+                                  description: Details about a terminated container
+                                  properties:
+                                    containerID:
+                                      description: Container's ID in the format '<type>://<container_id>'
+                                      type: string
+                                    exitCode:
+                                      description: Exit status from the last termination of the container
+                                      format: int32
+                                      type: integer
+                                    finishedAt:
+                                      description: Time at which the container last terminated
+                                      format: date-time
+                                      type: string
+                                    message:
+                                      description: Message regarding the last termination of the container
+                                      type: string
+                                    reason:
+                                      description: (brief) reason from the last termination of the container
+                                      type: string
+                                    signal:
+                                      description: Signal from the last termination of the container
+                                      format: int32
+                                      type: integer
+                                    startedAt:
+                                      description: Time at which previous execution of the container started
+                                      format: date-time
+                                      type: string
+                                  required:
+                                    - exitCode
+                                  type: object
+                                waiting:
+                                  description: Details about a waiting container
+                                  properties:
+                                    message:
+                                      description: Message regarding why the container is not yet running.
+                                      type: string
+                                    reason:
+                                      description: (brief) reason the container is not yet running.
+                                      type: string
+                                  type: object
+                              type: object
+                            name:
+                              description: |-
+                                Name is a DNS_LABEL representing the unique name of the container.
+                                Each container in a pod must have a unique name across all container types.
+                                Cannot be updated.
+                              type: string
+                            ready:
+                              description: |-
+                                Ready specifies whether the container is currently passing its readiness check.
+                                The value will change as readiness probes keep executing. If no readiness
+                                probes are specified, this field defaults to true once the container is
+                                fully started (see Started field).
 
-                            This field is immutable. It can only be set for containers.
-                          items:
-                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
-                            properties:
-                              name:
-                                description: |-
-                                  Name must match the name of one entry in pod.spec.resourceClaims of
-                                  the Pod where this field is used. It makes that resource available
-                                  inside a container.
-                                type: string
-                              request:
-                                description: |-
-                                  Request is the name chosen for a request in the referenced claim.
-                                  If empty, everything from the claim is made available, otherwise
-                                  only the result of this request.
-                                type: string
-                            required:
+                                The value is typically used to determine whether a container is ready to
+                                accept traffic.
+                              type: boolean
+                            resources:
+                              description: |-
+                                Resources represents the compute resource requests and limits that have been successfully
+                                enacted on the running container after it has been started or has been successfully resized.
+                              properties:
+                                claims:
+                                  description: |-
+                                    Claims lists the names of resources, defined in spec.resourceClaims,
+                                    that are used by this container.
+
+                                    This field depends on the
+                                    DynamicResourceAllocation feature gate.
+
+                                    This field is immutable. It can only be set for containers.
+                                  items:
+                                    description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                    properties:
+                                      name:
+                                        description: |-
+                                          Name must match the name of one entry in pod.spec.resourceClaims of
+                                          the Pod where this field is used. It makes that resource available
+                                          inside a container.
+                                        type: string
+                                      request:
+                                        description: |-
+                                          Request is the name chosen for a request in the referenced claim.
+                                          If empty, everything from the claim is made available, otherwise
+                                          only the result of this request.
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Limits describes the maximum amount of compute resources allowed.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Requests describes the minimum amount of compute resources required.
+                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                              type: object
+                            restartCount:
+                              description: |-
+                                RestartCount holds the number of times the container has been restarted.
+                                Kubelet makes an effort to always increment the value, but there
+                                are cases when the state may be lost due to node restarts and then the value
+                                may be reset to 0. The value is never negative.
+                              format: int32
+                              type: integer
+                            started:
+                              description: |-
+                                Started indicates whether the container has finished its postStart lifecycle hook
+                                and passed its startup probe.
+                                Initialized as false, becomes true after startupProbe is considered
+                                successful. Resets to false when the container is restarted, or if kubelet
+                                loses state temporarily. In both cases, startup probes will run again.
+                                Is always true when no startupProbe is defined and container is running and
+                                has passed the postStart lifecycle hook. The null value must be treated the
+                                same as false.
+                              type: boolean
+                            state:
+                              description: State holds details about the container's current condition.
+                              properties:
+                                running:
+                                  description: Details about a running container
+                                  properties:
+                                    startedAt:
+                                      description: Time at which the container was last (re-)started
+                                      format: date-time
+                                      type: string
+                                  type: object
+                                terminated:
+                                  description: Details about a terminated container
+                                  properties:
+                                    containerID:
+                                      description: Container's ID in the format '<type>://<container_id>'
+                                      type: string
+                                    exitCode:
+                                      description: Exit status from the last termination of the container
+                                      format: int32
+                                      type: integer
+                                    finishedAt:
+                                      description: Time at which the container last terminated
+                                      format: date-time
+                                      type: string
+                                    message:
+                                      description: Message regarding the last termination of the container
+                                      type: string
+                                    reason:
+                                      description: (brief) reason from the last termination of the container
+                                      type: string
+                                    signal:
+                                      description: Signal from the last termination of the container
+                                      format: int32
+                                      type: integer
+                                    startedAt:
+                                      description: Time at which previous execution of the container started
+                                      format: date-time
+                                      type: string
+                                  required:
+                                    - exitCode
+                                  type: object
+                                waiting:
+                                  description: Details about a waiting container
+                                  properties:
+                                    message:
+                                      description: Message regarding why the container is not yet running.
+                                      type: string
+                                    reason:
+                                      description: (brief) reason the container is not yet running.
+                                      type: string
+                                  type: object
+                              type: object
+                            stopSignal:
+                              description: StopSignal reports the effective stop signal for this container
+                              type: string
+                            user:
+                              description: User represents user identity information initially attached to the first process of the container
+                              properties:
+                                linux:
+                                  description: |-
+                                    Linux holds user identity information initially attached to the first process of the containers in Linux.
+                                    Note that the actual running identity can be changed if the process has enough privilege to do so.
+                                  properties:
+                                    gid:
+                                      description: GID is the primary gid initially attached to the first process in the container
+                                      format: int64
+                                      type: integer
+                                    supplementalGroups:
+                                      description: SupplementalGroups are the supplemental groups initially attached to the first process in the container
+                                      items:
+                                        format: int64
+                                        type: integer
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    uid:
+                                      description: UID is the primary uid initially attached to the first process in the container
+                                      format: int64
+                                      type: integer
+                                  required:
+                                    - gid
+                                    - uid
+                                  type: object
+                              type: object
+                            volumeMounts:
+                              description: Status of volume mounts.
+                              items:
+                                description: VolumeMountStatus shows status of volume mounts.
+                                properties:
+                                  mountPath:
+                                    description: MountPath corresponds to the original VolumeMount.
+                                    type: string
+                                  name:
+                                    description: Name corresponds to the name of the original VolumeMount.
+                                    type: string
+                                  readOnly:
+                                    description: ReadOnly corresponds to the original VolumeMount.
+                                    type: boolean
+                                  recursiveReadOnly:
+                                    description: |-
+                                      RecursiveReadOnly must be set to Disabled, Enabled, or unspecified (for non-readonly mounts).
+                                      An IfPossible value in the original VolumeMount must be translated to Disabled or Enabled,
+                                      depending on the mount result.
+                                    type: string
+                                required:
+                                  - mountPath
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - mountPath
+                              x-kubernetes-list-type: map
+                          required:
+                            - image
+                            - imageID
                             - name
-                            type: object
-                          type: array
-                          x-kubernetes-list-map-keys:
+                            - ready
+                            - restartCount
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      message:
+                        description: A human readable message indicating details about why the pod is in this condition.
+                        type: string
+                      nominatedNodeName:
+                        description: |-
+                          nominatedNodeName is set only when this pod preempts other pods on the node, but it cannot be
+                          scheduled right away as preemption victims receive their graceful termination periods.
+                          This field does not guarantee that the pod will be scheduled on this node. Scheduler may decide
+                          to place the pod elsewhere if other nodes become available sooner. Scheduler may also decide to
+                          give the resources on this node to a higher priority pod that is created after preemption.
+                          As a result, this field may be different than PodSpec.nodeName when the pod is
+                          scheduled.
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          If set, this represents the .metadata.generation that the pod status was set based upon.
+                          The PodObservedGenerationTracking feature gate must be enabled to use this field.
+                        format: int64
+                        type: integer
+                      phase:
+                        description: |-
+                          The phase of a Pod is a simple, high-level summary of where the Pod is in its lifecycle.
+                          The conditions array, the reason and message fields, and the individual container status
+                          arrays contain more detail about the pod's status.
+                          There are five possible phase values:
+
+                          Pending: The pod has been accepted by the Kubernetes system, but one or more of the
+                          container images has not been created. This includes time before being scheduled as
+                          well as time spent downloading images over the network, which could take a while.
+                          Running: The pod has been bound to a node, and all of the containers have been created.
+                          At least one container is still running, or is in the process of starting or restarting.
+                          Succeeded: All containers in the pod have terminated in success, and will not be restarted.
+                          Failed: All containers in the pod have terminated, and at least one container has
+                          terminated in failure. The container either exited with non-zero status or was terminated
+                          by the system.
+                          Unknown: For some reason the state of the pod could not be obtained, typically due to an
+                          error in communicating with the host of the pod.
+
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-phase
+                        type: string
+                      podIP:
+                        description: |-
+                          podIP address allocated to the pod. Routable at least within the cluster.
+                          Empty if not yet allocated.
+                        type: string
+                      podIPs:
+                        description: |-
+                          podIPs holds the IP addresses allocated to the pod. If this field is specified, the 0th entry must
+                          match the podIP field. Pods may be allocated at most 1 value for each of IPv4 and IPv6. This list
+                          is empty if no IPs have been allocated yet.
+                        items:
+                          description: PodIP represents a single IP address allocated to the pod.
+                          properties:
+                            ip:
+                              description: IP is the IP address assigned to the pod
+                              type: string
+                          required:
+                            - ip
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - ip
+                        x-kubernetes-list-type: map
+                      qosClass:
+                        description: |-
+                          The Quality of Service (QOS) classification assigned to the pod based on resource requirements
+                          See PodQOSClass type for available QOS classes
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/#quality-of-service-classes
+                        type: string
+                      reason:
+                        description: |-
+                          A brief CamelCase message indicating details about why the pod is in this state.
+                          e.g. 'Evicted'
+                        type: string
+                      resize:
+                        description: |-
+                          Status of resources resize desired for pod's containers.
+                          It is empty if no resources resize is pending.
+                          Any changes to container resources will automatically set this to "Proposed"
+                          Deprecated: Resize status is moved to two pod conditions PodResizePending and PodResizeInProgress.
+                          PodResizePending will track states where the spec has been resized, but the Kubelet has not yet allocated the resources.
+                          PodResizeInProgress will track in-progress resizes, and should be present whenever allocated resources != acknowledged resources.
+                        type: string
+                      resourceClaimStatuses:
+                        description: Status of resource claims.
+                        items:
+                          description: |-
+                            PodResourceClaimStatus is stored in the PodStatus for each PodResourceClaim
+                            which references a ResourceClaimTemplate. It stores the generated name for
+                            the corresponding ResourceClaim.
+                          properties:
+                            name:
+                              description: |-
+                                Name uniquely identifies this resource claim inside the pod.
+                                This must match the name of an entry in pod.spec.resourceClaims,
+                                which implies that the string must be a DNS_LABEL.
+                              type: string
+                            resourceClaimName:
+                              description: |-
+                                ResourceClaimName is the name of the ResourceClaim that was
+                                generated for the Pod in the namespace of the Pod. If this is
+                                unset, then generating a ResourceClaim was not necessary. The
+                                pod.spec.resourceClaims entry can be ignored in this case.
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
                           - name
-                          x-kubernetes-list-type: map
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: |-
-                            Limits describes the maximum amount of compute resources allowed.
-                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: |-
-                            Requests describes the minimum amount of compute resources required.
-                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                          type: object
-                      type: object
-                    startTime:
-                      description: |-
-                        RFC 3339 date and time at which the object was acknowledged by the Kubelet.
-                        This is before the Kubelet pulled the container image(s) for the pod.
-                      format: date-time
-                      type: string
-                  type: object
-                type: array
-              state:
-                description: State field that defines status of the IBMLicensing
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                        x-kubernetes-list-type: map
+                      resources:
+                        description: |-
+                          Resources represents the compute resource requests and limits that have been
+                          applied at the pod level if pod-level requests or limits are set in
+                          PodSpec.Resources
+                        properties:
+                          claims:
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+                              This field depends on the
+                              DynamicResourceAllocation feature gate.
+
+                              This field is immutable. It can only be set for containers.
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                                request:
+                                  description: |-
+                                    Request is the name chosen for a request in the referenced claim.
+                                    If empty, everything from the claim is made available, otherwise
+                                    only the result of this request.
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                              - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                        type: object
+                      startTime:
+                        description: |-
+                          RFC 3339 date and time at which the object was acknowledged by the Kubelet.
+                          This is before the Kubelet pulled the container image(s) for the pod.
+                        format: date-time
+                        type: string
+                    type: object
+                  type: array
+                state:
+                  description: State field that defines status of the IBMLicensing
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/config/manifests/bases/ibm-licensing-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-licensing-operator.clusterserviceversion.yaml
@@ -8,8 +8,7 @@ metadata:
     certified: "false"
     containerImage: icr.io/cpopen/ibm-licensing-operator:4.2.24
     createdAt: "2020-06-22T10:22:31Z"
-    description: The IBM Licensing Operator provides a Kubernetes CRD-Based API to
-      monitor the license usage of products.
+    description: The IBM Licensing Operator provides a Kubernetes CRD-Based API to monitor the license usage of products.
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
     features.operators.openshift.io/proxy-aware: "false"
@@ -21,8 +20,7 @@ metadata:
     olm.skipRange: '>=1.0.0 <4.2.24'
     operatorframework.io/suggested-namespace: ibm-licensing
     operators.operatorframework.io/builder: operator-sdk-v1.25.2
-    operators.operatorframework.io/internal-objects: '["ibmlicensingmetadatas.operator.ibm.com",
-      "ibmlicensingdefinitions.operator.ibm.com", "ibmlicensingquerysources.operator.ibm.com"]'
+    operators.operatorframework.io/internal-objects: '["ibmlicensingmetadatas.operator.ibm.com", "ibmlicensingdefinitions.operator.ibm.com", "ibmlicensingquerysources.operator.ibm.com"]'
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
   labels:
     app.kubernetes.io/instance: ibm-licensing-operator
@@ -39,347 +37,325 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: |-
-        IBMLicensingDefinition is a custom resource for internal use only. It is used by some IBM products to assign their pods to the licensed products for the licensing specific calculation, performed by the IBM License Service.
-        It is prepared in close collaboration with those IBM products, and affects only them. It cannot be modified by a customer, to ensure compliance with the license usage metering and reporting.
-      displayName: IBM Licensing Definition
-      kind: IBMLicensingDefinition
-      name: ibmlicensingdefinitions.operator.ibm.com
-      version: v1
-    - description: |-
-        IBMLicensingMetadata is the schema for IBM License Service. Thanks to IBMLicensingMetadata, you can track
-        the license usage of Virtual Processor Core (VPC) metric by Pods that are managed by automation,
-        for which licensing annotations are not defined at the time of deployment, such as the open source OpenLiberty.
-        / For more information, see documentation: https://ibm.biz/icpfs39install.
-        License: By installing this product you accept the license terms. For more information about the license,
-        see https://ibm.biz/icpfs39license.
-      displayName: IBMLicensing Metadata
-      kind: IBMLicensingMetadata
-      name: ibmlicensingmetadatas.operator.ibm.com
-      version: v1alpha1
-    - description: |-
-        IBMLicensingQuerySource is a custom resource for internal use only. It is used by some IBM products to assign their pods to the licensed products for the licensing specific calculation, performed by the IBM License Service.
-        It is prepared in close collaboration with those IBM products, and affects only them. It cannot be modified by a customer, to ensure compliance with the license usage metering and reporting.
-      displayName: IBM Licensing Query Source
-      kind: IBMLicensingQuerySource
-      name: ibmlicensingquerysources.operator.ibm.com
-      version: v1
-    - description: |-
-        IBMLicensing custom resource is used to create an instance of the License Service, used to collect information about license usage of IBM containerized products and IBM Cloud Paks per cluster.
-        You can retrieve license usage data through a dedicated API call and generate an audit snapshot on demand.
-        Documentation: For additional details regarding install parameters check: https://ibm.biz/icpfs39install.
-        License: Please refer to the IBM Terms website (ibm.biz/lsvc-lic)
-        to find the license terms for the particular IBM product for which you are deploying this component.
-      displayName: IBM License Service
-      kind: IBMLicensing
-      name: ibmlicensings.operator.ibm.com
-      resources:
-      - kind: ClusterRole
-        name: ""
-        version: v1
-      - kind: ClusterRoleBinding
-        name: ""
-        version: v1
-      - kind: Deployment
-        name: ""
-        version: v1
-      - kind: Gateway
-        name: ""
-        version: gateway.networking.k8s.io/v1
-      - kind: HTTPRoute
-        name: ""
-        version: gateway.networking.k8s.io/v1
-      - kind: Pod
-        name: ""
-        version: v1
-      - kind: ReplicaSets
-        name: ""
-        version: v1
-      - kind: Role
-        name: ""
-        version: v1
-      - kind: RoleBinding
-        name: ""
-        version: v1
-      - kind: Route
-        name: ""
-        version: v1
-      - kind: Secret
-        name: ""
-        version: v1
-      - kind: Service
-        name: ""
-        version: v1
-      - kind: ServiceAccount
-        name: ""
-        version: v1
-      - kind: configmaps
-        name: ""
-        version: v1
-      - kind: ibmlicensingmetadatas
-        name: ""
-        version: v1alpha1
-      - kind: ibmlicensings
-        name: ""
-        version: v1alpha1
-      - kind: status
-        name: ""
-        version: v1alpha1
-      specDescriptors:
-      - description: Annotations to be copied into all relevant resources
-        displayName: Annotations
-        path: annotations
-      - description: Consider updating to enable chargeback feature
-        displayName: Chargeback Enabled
-        path: chargebackEnabled
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Chargeback data retention period in days. Default value is 62
-          days.
-        displayName: Chargeback Retention Period in days
-        path: chargebackRetentionPeriod
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:number
-      - description: 'Where should data be collected, options: metering, datacollector'
-        displayName: Datasource
-        path: datasource
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Environment variable setting
-        displayName: Environment variable setting
-        path: envVariable
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Set additional features under this field
-        displayName: Features
-        path: features
-      - description: Change alerting settings.
-        displayName: Alerting settings
-        path: features.alerting
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Should this function be enabled.
-        displayName: Enabled
-        path: features.alerting.enabled
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Authorization settings.
-        displayName: Auth
-        path: features.auth
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Enable URL based Auth
-        displayName: Url Based Based Enabled
-        path: features.auth.urlBasedEnabled
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Configure if you have HyperThreading (HT) or Symmetrical Multi-Threading
-          (SMT) enabled
-        displayName: Hyper Threading
-        path: features.hyperThreading
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: |-
-          Enables node CPU capping. When false, the operand will skip calls to the Kubernetes node API; node-capping is not applied and metrics may exceed
-          real node capacity. Defaults to true.
-        displayName: Node CPU Capping Enabled
-        path: features.nodeCpuCappingEnabled
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - description: Special terms, must be granted by IBM Pricing.
-        displayName: Custom namespaces Config Map
-        path: features.nssConfigMap
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Limit for failed namespace access attempts before reporting an
-          error in custom namespaces scoping.
-        displayName: Namespace Scope Denial Limit
-        path: features.nssDenialLimit
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
+          IBMLicensingDefinition is a custom resource for internal use only. It is used by some IBM products to assign their pods to the licensed products for the licensing specific calculation, performed by the IBM License Service.
+          It is prepared in close collaboration with those IBM products, and affects only them. It cannot be modified by a customer, to ensure compliance with the license usage metering and reporting.
+        displayName: IBM Licensing Definition
+        kind: IBMLicensingDefinition
+        name: ibmlicensingdefinitions.operator.ibm.com
+        version: v1
       - description: |-
-          Restricts IBM License Service to watching only the namespaces specified in the WATCH_NAMESPACE operator environment variable or in the ConfigMap referenced by .features.nssConfigMap.
-          This feature requires authorization from IBM Pricing.
-        displayName: Namespace scope enabled
-        path: features.nssEnabled
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Change prometheus query source settings.
-        displayName: Prometheus query source settings
-        path: features.prometheusQuerySource
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Should this function be enabled (by default it is).
-        displayName: Enabled
-        path: features.prometheusQuerySource.enabled
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:text
-      - description: What url to use for prometheus API (by default use OCP Thanos
-          Querier).
-        displayName: URL
-        path: features.prometheusQuerySource.url
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Should Gateway be created to expose IBM Licensing Service API?
-          Default is true.
-        displayName: Gateway Enabled
-        path: gatewayEnabled
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - description: If Gateway is enabled, you can set its parameters
-        displayName: Gateway Options
-        path: gatewayOptions
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Additional annotations that should include f.e. gateway class
-          if using not default gateway controller
-        displayName: Annotations
-        path: gatewayOptions.annotations
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Switch for enabling Gateway API on Openshift. Default is false.
-        displayName: Enable Gateway API on Openshift
-        path: gatewayOptions.enableGatewayAPIOpenshift
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - description: GatewayClassName defines gateway class name option to be passed
-          to the gateway spec field. Default is ibm-licensing.
-        displayName: GatewayClassName
-        path: gatewayOptions.gatewayClassName
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:text
-      - description: HTTPS port for Gateway listener. Default is 443. Only used when
-          TLSSecretName is set.
-        displayName: HTTPS Port
-        path: gatewayOptions.httpsPort
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:number
-      - description: TLS Options to enable secure connection. Default is ibm-license-service-cert-internal.
-        displayName: TLS Secret Name
-        path: gatewayOptions.tlsSecretName
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Enables https access at pod level, httpsCertsSource needed if
-          true
-        displayName: HTTPS Enable
-        path: httpsEnable
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:text
+          IBMLicensingMetadata is the schema for IBM License Service. Thanks to IBMLicensingMetadata, you can track
+          the license usage of Virtual Processor Core (VPC) metric by Pods that are managed by automation,
+          for which licensing annotations are not defined at the time of deployment, such as the open source OpenLiberty.
+          / For more information, see documentation: https://ibm.biz/icpfs39install.
+          License: By installing this product you accept the license terms. For more information about the license,
+          see https://ibm.biz/icpfs39license.
+        displayName: IBMLicensing Metadata
+        kind: IBMLicensingMetadata
+        name: ibmlicensingmetadatas.operator.ibm.com
+        version: v1alpha1
       - description: |-
-          Existing or to be created namespace where application will start. In case metering data collection is used,
-          should be the same namespace as metering components
-        displayName: Instance Namespace
-        path: instanceNamespace
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Labels to be copied into all relevant resources
-        displayName: Labels
-        path: labels
-      - description: IBM License Service license acceptance.
-        displayName: License Acceptance
-        path: license
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:text
-      - description: 'By installing the IBM License Service, you accept the license
-          terms for the particular IBM product for which you are deploying this component:
-          ibm.biz/lsvc-lic.'
-        displayName: License acceptance
-        path: license.accept
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:checkbox
-      - description: Is Red Hat Marketplace enabled
-        displayName: RHMP Enabled
-        path: rhmpEnabled
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Should Route be created to expose IBM Licensing Service API?
-          (only on OpenShift cluster)
-        displayName: Route Enabled
-        path: routeEnabled
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:text
-      - description: If default SCC user ID fails, you can set runAsUser option to
-          fix that
-        displayName: Security Context
-        path: securityContext
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Sender configuration, set if you have multi-cluster environment
-          from which you collect data
-        displayName: Sender
-        path: sender
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Unique ID of reporting cluster
-        displayName: Cluster ID
-        path: sender.clusterID
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:text
-      - description: What is the name of this reporting cluster in multi-cluster system.
-          If not provided, CLUSTER_ID will be used as CLUSTER_NAME at Operand level
-        displayName: Cluster Name
-        path: sender.clusterName
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Frequency of workloads scans as cron expression. If not provided,
-          workloads reporting is disabled.
-        displayName: Workloads Reporting Frequency
-        path: sender.frequency
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:text
-        - urn:alm:descriptor:io.kubernetes:hidden
-      - description: Name of the secret that contains the License Service Reporter
-          certificate(s) used to establish a secure connection with it. You need to
-          create it in instance namespace
-        displayName: Reporter Certificates Secret Name
-        path: sender.reporterCertsSecretName
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:text
-      - description: License Service Reporter authentication token, provided by secret
-          that you need to create in instance namespace
-        displayName: Reporter Secret Token
-        path: sender.reporterSecretToken
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:text
-      - description: URL for License Service Reporter receiver that collects and aggregate
-          multi cluster licensing data.
-        displayName: Reporter URL
-        path: sender.reporterURL
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Enable certificates validation when uploading data to the License
-          Service Reporter
-        displayName: Validate Reporter Certificates
-        path: sender.validateReporterCerts
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - description: Software Central integration configuration
-        displayName: Software Central
-        path: softwareCentral
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Enable automatic upload to Software Central
-        displayName: Enable Software Central
-        path: softwareCentral.enable
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - description: Name of the Kubernetes secret in ibm-licensing namespace containing
-          IBM Entitlement Key
-        displayName: Entitlement Key Secret
-        path: softwareCentral.entitlementKeySecret
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:text
-      - description: 'Cron expression for upload schedule (default: "5 0 * * *")'
-        displayName: Upload Frequency
-        path: softwareCentral.frequency
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:text
-      - description: 'Use sandbox environment (default: false)'
-        displayName: Sandbox Mode
-        path: softwareCentral.sandbox
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      version: v1alpha1
+          IBMLicensingQuerySource is a custom resource for internal use only. It is used by some IBM products to assign their pods to the licensed products for the licensing specific calculation, performed by the IBM License Service.
+          It is prepared in close collaboration with those IBM products, and affects only them. It cannot be modified by a customer, to ensure compliance with the license usage metering and reporting.
+        displayName: IBM Licensing Query Source
+        kind: IBMLicensingQuerySource
+        name: ibmlicensingquerysources.operator.ibm.com
+        version: v1
+      - description: |-
+          IBMLicensing custom resource is used to create an instance of the License Service, used to collect information about license usage of IBM containerized products and IBM Cloud Paks per cluster.
+          You can retrieve license usage data through a dedicated API call and generate an audit snapshot on demand.
+          Documentation: For additional details regarding install parameters check: https://ibm.biz/icpfs39install.
+          License: Please refer to the IBM Terms website (ibm.biz/lsvc-lic)
+          to find the license terms for the particular IBM product for which you are deploying this component.
+        displayName: IBM License Service
+        kind: IBMLicensing
+        name: ibmlicensings.operator.ibm.com
+        resources:
+          - kind: ClusterRole
+            name: ""
+            version: v1
+          - kind: ClusterRoleBinding
+            name: ""
+            version: v1
+          - kind: Deployment
+            name: ""
+            version: v1
+          - kind: Gateway
+            name: ""
+            version: gateway.networking.k8s.io/v1
+          - kind: HTTPRoute
+            name: ""
+            version: gateway.networking.k8s.io/v1
+          - kind: Pod
+            name: ""
+            version: v1
+          - kind: ReplicaSets
+            name: ""
+            version: v1
+          - kind: Role
+            name: ""
+            version: v1
+          - kind: RoleBinding
+            name: ""
+            version: v1
+          - kind: Route
+            name: ""
+            version: v1
+          - kind: Secret
+            name: ""
+            version: v1
+          - kind: Service
+            name: ""
+            version: v1
+          - kind: ServiceAccount
+            name: ""
+            version: v1
+          - kind: configmaps
+            name: ""
+            version: v1
+          - kind: ibmlicensingmetadatas
+            name: ""
+            version: v1alpha1
+          - kind: ibmlicensings
+            name: ""
+            version: v1alpha1
+          - kind: status
+            name: ""
+            version: v1alpha1
+        specDescriptors:
+          - description: Annotations to be copied into all relevant resources
+            displayName: Annotations
+            path: annotations
+          - description: Consider updating to enable chargeback feature
+            displayName: Chargeback Enabled
+            path: chargebackEnabled
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: Chargeback data retention period in days. Default value is 62 days.
+            displayName: Chargeback Retention Period in days
+            path: chargebackRetentionPeriod
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:number
+          - description: 'Where should data be collected, options: metering, datacollector'
+            displayName: Datasource
+            path: datasource
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: Environment variable setting
+            displayName: Environment variable setting
+            path: envVariable
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:hidden
+          - description: Set additional features under this field
+            displayName: Features
+            path: features
+          - description: Change alerting settings.
+            displayName: Alerting settings
+            path: features.alerting
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:hidden
+          - description: Should this function be enabled.
+            displayName: Enabled
+            path: features.alerting.enabled
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: Authorization settings.
+            displayName: Auth
+            path: features.auth
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:hidden
+          - description: Enable URL based Auth
+            displayName: Url Based Based Enabled
+            path: features.auth.urlBasedEnabled
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:hidden
+          - description: Configure if you have HyperThreading (HT) or Symmetrical Multi-Threading (SMT) enabled
+            displayName: Hyper Threading
+            path: features.hyperThreading
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:hidden
+          - description: |-
+              Enables node CPU capping. When false, the operand will skip calls to the Kubernetes node API; node-capping is not applied and metrics may exceed
+              real node capacity. Defaults to true.
+            displayName: Node CPU Capping Enabled
+            path: features.nodeCpuCappingEnabled
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+          - description: Special terms, must be granted by IBM Pricing.
+            displayName: Custom namespaces Config Map
+            path: features.nssConfigMap
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:hidden
+          - description: Limit for failed namespace access attempts before reporting an error in custom namespaces scoping.
+            displayName: Namespace Scope Denial Limit
+            path: features.nssDenialLimit
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:hidden
+          - description: |-
+              Restricts IBM License Service to watching only the namespaces specified in the WATCH_NAMESPACE operator environment variable or in the ConfigMap referenced by .features.nssConfigMap.
+              This feature requires authorization from IBM Pricing.
+            displayName: Namespace scope enabled
+            path: features.nssEnabled
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:hidden
+          - description: Change prometheus query source settings.
+            displayName: Prometheus query source settings
+            path: features.prometheusQuerySource
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:hidden
+          - description: Should this function be enabled (by default it is).
+            displayName: Enabled
+            path: features.prometheusQuerySource.enabled
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: What url to use for prometheus API (by default use OCP Thanos Querier).
+            displayName: URL
+            path: features.prometheusQuerySource.url
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:hidden
+          - description: Should Gateway be created to expose IBM Licensing Service API? Default is true.
+            displayName: Gateway Enabled
+            path: gatewayEnabled
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+          - description: If Gateway is enabled, you can set its parameters
+            displayName: Gateway Options
+            path: gatewayOptions
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: Additional annotations that should include f.e. gateway class if using not default gateway controller
+            displayName: Annotations
+            path: gatewayOptions.annotations
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: Switch for enabling Gateway API on Openshift. Default is false.
+            displayName: Enable Gateway API on Openshift
+            path: gatewayOptions.enableGatewayAPIOpenshift
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+          - description: GatewayClassName defines gateway class name option to be passed to the gateway spec field. Default is ibm-licensing.
+            displayName: GatewayClassName
+            path: gatewayOptions.gatewayClassName
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: HTTPS port for Gateway listener. Default is 443. Only used when TLSSecretName is set.
+            displayName: HTTPS Port
+            path: gatewayOptions.httpsPort
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:number
+          - description: TLS Options to enable secure connection. Default is ibm-license-service-cert-internal.
+            displayName: TLS Secret Name
+            path: gatewayOptions.tlsSecretName
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: Enables https access at pod level, httpsCertsSource needed if true
+            displayName: HTTPS Enable
+            path: httpsEnable
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: |-
+              Existing or to be created namespace where application will start. In case metering data collection is used,
+              should be the same namespace as metering components
+            displayName: Instance Namespace
+            path: instanceNamespace
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: Labels to be copied into all relevant resources
+            displayName: Labels
+            path: labels
+          - description: IBM License Service license acceptance.
+            displayName: License Acceptance
+            path: license
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: 'By installing the IBM License Service, you accept the license terms for the particular IBM product for which you are deploying this component: ibm.biz/lsvc-lic.'
+            displayName: License acceptance
+            path: license.accept
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:checkbox
+          - description: Is Red Hat Marketplace enabled
+            displayName: RHMP Enabled
+            path: rhmpEnabled
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: Should Route be created to expose IBM Licensing Service API? (only on OpenShift cluster)
+            displayName: Route Enabled
+            path: routeEnabled
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: If default SCC user ID fails, you can set runAsUser option to fix that
+            displayName: Security Context
+            path: securityContext
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: Sender configuration, set if you have multi-cluster environment from which you collect data
+            displayName: Sender
+            path: sender
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: Unique ID of reporting cluster
+            displayName: Cluster ID
+            path: sender.clusterID
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: What is the name of this reporting cluster in multi-cluster system. If not provided, CLUSTER_ID will be used as CLUSTER_NAME at Operand level
+            displayName: Cluster Name
+            path: sender.clusterName
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: Frequency of workloads scans as cron expression. If not provided, workloads reporting is disabled.
+            displayName: Workloads Reporting Frequency
+            path: sender.frequency
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+              - urn:alm:descriptor:io.kubernetes:hidden
+          - description: Name of the secret that contains the License Service Reporter certificate(s) used to establish a secure connection with it. You need to create it in instance namespace
+            displayName: Reporter Certificates Secret Name
+            path: sender.reporterCertsSecretName
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: License Service Reporter authentication token, provided by secret that you need to create in instance namespace
+            displayName: Reporter Secret Token
+            path: sender.reporterSecretToken
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: URL for License Service Reporter receiver that collects and aggregate multi cluster licensing data.
+            displayName: Reporter URL
+            path: sender.reporterURL
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: Enable certificates validation when uploading data to the License Service Reporter
+            displayName: Validate Reporter Certificates
+            path: sender.validateReporterCerts
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+          - description: Software Central integration configuration
+            displayName: Software Central
+            path: softwareCentral
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: Enable automatic upload to Software Central
+            displayName: Enable Software Central
+            path: softwareCentral.enable
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+          - description: Name of the Kubernetes secret in ibm-licensing namespace containing IBM Entitlement Key
+            displayName: Entitlement Key Secret
+            path: softwareCentral.entitlementKeySecret
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: 'Cron expression for upload schedule (default: "5 0 * * *")'
+            displayName: Upload Frequency
+            path: softwareCentral.frequency
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: 'Use sandbox environment (default: false)'
+            displayName: Sandbox Mode
+            path: softwareCentral.sandbox
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        version: v1alpha1
   description: |-
     **Important:**
     - If you are using the IBM Licensing Operator as part of an IBM Cloud Pak, see the documentation for that IBM Cloud Pak to learn more about how to install and use the operator service. For the link to your IBM Cloud Pak documentation, see [IBM Cloud Paks that use Common Services](https://ibm.biz/BdyGwb).
@@ -398,42 +374,42 @@ spec:
      Prerequisites depend on the integration of the License Service with an IBM Cloud Pak or IBM Containerized Software. For more information, see the applicable IBM Cloud Pak documentation or [ibm-licensing-operator for stand-alone IBM Containerized Software](https://ibm.biz/BdyGwh).
   displayName: IBM Licensing
   icon:
-  - base64data: iVBORw0KGgoAAAANSUhEUgAAAK8AAACvCAMAAAC8TH5HAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAB1UExURQAAAJGS77CC4pCS75yM64uV8pSQ7puA85OV87OB4auF5Hyd+H2c936b9n6b94Ca9n+b9n+b9n+b9qOJ56SI55yM6qSI536b96aH5q2D45mN64OZ9ZWQ7oyU8XWg+6uG5oqg/p6L6m+k/ZuY+3mr/6qQ9LqM80D8C0oAAAAbdFJOUwA67R4KKxMBBP6ak6vZgVtJxG5ot+hQ7YDVkwC2C58AAAuSSURBVHja7ZyJerK8EoCDCSTKjoiIS13of/+XeGYm4NLKrvj1OYxt7aa8TiazJZGxSSaZZJJJJvmcSCn/Eq7Cz79DLJk0rb+kXdM9nz0m/4p2mZufz3lAZvEn1HsGye2J9128h7/Gezj8Nd7D3+I9/xu8SjWHrS76bfN8A+NsYxjowCvbPN+QSGB6kWi6QHteyQLPfx+wYsH2eHSthgu05lXMy/PceRcwxtnjdnts4mjLq5hBceVdcVsya71FMeov0JIXMuQwR+DoXX5EMgf0uz2GrDYbb8mrmE+4Z/NdvDCApN+jX3uFdrySqfW70wzFbFLwWtVNkXa8ONlIvfx9Dk0xSyvYq0NpxasYJ9o8emcUVCw6EjGvuUpLXgfVm9cP1fAZp1yyCKeGBf8pB96g9jUZ57c6s1vIIAUfjXqY9eFg1yiuKJnOECzeW+TJm0+rxRGGWfcP7/dld8bZwqcp/dJqIs9hrJIJ/JD2abV5j1StfJn1/pofo/Kx0ae1KfAO7/Vld7anfVpf28M5kKPDc9kYLRW4RDhIwYV/PozVUAF39Qre3BmrvsM04nisjHHyJlUjZEOefuBj8UIA81zHfGJ84BYeHAP9LKseP1r5LNnvOlHeXJgqRZbUPzT97PHvBVb48VCX09W54du2u3ZJwjD0It/gqmCue/yoolm4b7tQjmohh7cGAWzHC8x/qOFOZmBG4bbERDkQrVYyiGP7iPwPLGrgsAofYbePonEJ2CHxAuvjxEjLvfUj7J1BaP0irY3i888SA63l3alWgwKjbXueZztOSBoucOE33huIZdsWHChXRds72O069PyHhSEBDiOynbAEBiGreCGJKoa5zT8GVBzt4QNgXc+wbq4YvW+hSMkDYNa4EYihWqlYtmouSsYTo4XvgWezHKDcI+7xuPbMMp7JH0GEfhZGRMDIG5FRtLG1IGCNvTp/d9nFZhMx/DXYH/cgSBv6SscM+Tyf0P450Lw+iCmbOGAMonOeO/XlMyTjgAsfmWAN9Y53RFy0hDAovXBDSBFBVAIHDdUJ2lre3J6AVG9Hcln5NQyKCUcrd390g5/BtjpNR2KNGwTVpRDSmk6et6jwCv0ScVhpxopxl3DBIjzVjrYk5gVuEPAaw7UP+aFV+0ex5Aq8y/hTYhiE/UXjhibrlBUisUm8hmHwqujuH3IqQLA/0dT+Af8Q34hT8du3QXlR4nrdkxhJ0554nwAXhpvj+hLUo2u/zWoJM1aXy70ZP8e97APWJ+WGbN1AXNP8tedAasM96PLu4Ik2jhpHZLkqgdGM5TNjuKzNnhkiUmneH8CSCe9wpXV429HDlCu7GcV9JwemWoEbWr3rGZx2iMs5F4+T3S1p89DoYGvkUeLCKC67m+uBsVwVuGpI+QVohGtZ6rHrU+Cu/UaP/ps4KY3iWhlipwNwd4Arh1WLCIy4lpA/2yiF4XZ9ehgMuaRgt7r6FMWiC9DuL64YWtyCrQKuEOLe1iJsG+eO2W8eo+POdrvVtdULrgG0Dbg76xW1uCDcm5GCguzDAeNlz0qPqgfzGunJeAl4aOug6KYQ7l2WhI7DZEMqZ7L5a1uBZWTQF3/QVHvmUosOBX0ZVkbfkgNtDYCbDcDVsIKbQYCJBCY/gak7FHQh+bqiX7LwsnuYfr1gqUTCUsPWgsWdF1H2I1/ZoYBMSLs3o3/blyke+FRiEPE9c1Huq9dpV60GWQNmvybSIrCnee0SGIlDJzJfVzwrttTq7bfkUNCSzV71a19pScNOGHrmi9pWV/Uue6lXYpEcBFfgslSOPG0MBTASc/YK3455PEqvyYY5r0G4AeH6gWHqSCyVxQ2s9ksJw9B/ATBYVUy8fdRL6ZhhlPo1HpIyHelM38OmCuA6oWvzwTah69DTbiW6qxdMCdPdAIGLbrC8lyIimxHRgrhQcA+cdoqluxXc0u7qhcTGNBAYeKkB9CTASfJjVuTo7mvoRsO676Ci+LRanVbd91YgLggp2GI1/kpRq7MAXnuDjBhC8Qpkl3UepwIXgblseDQq2XBcUK8bru0hGgbni7ynzrMNs1xOuJDmNQMAsfAI2B0CjOaAvKuuK2aES8C8XU8Sn98H9SKw12/SwfwVzNyArOLOL1lxEpO37/lKFujlpW3UfTSZwpxaQCkXb+JVd3OAAg1xrQ4vFGzC0MDrbuvLSGtRiSVYuonjeNU5MxMWAVudZzct1azdLmUXzGZLV7BCySxG6Zrq4MsFXqv79A7WiLu1OwwLFgElr7VA3LQjLtZnCCx7+KNo7a4BuG3lhRmKWXQ0LME40Gbxsqt6BQH3arExZ+viCl67Ib1rGHFLQPIQL7JFnHTjRfUCb68whR1mXM3dttpjcWvIAS6uNCRxlmVxxypeCVJw3wjl0/LzmrfaVG4kBgFT6ge57wJ4M7OTfmlNS4j+McpB4G2rTfBGkhAwp2UcWfB2cw/FFogBKQvxrhtTLMnMZYJiFG4eeLM0zVLRg3dIzmJvAbfRgiXjS81rXfeBLIE3TTuVQneZeH8Fb4HXFQ0rcGKJcsNFXsRdduYdViSQBQNy0LCilaSIu+R3TeqP8KKLQAXXzjgw3hR5l3erFvoldOOVr9Cv5eK6v1tzXch0UZfLNGEPvGQi3fU7tMi1m45PgCtb4Nin974Lftmd9yUtJZ94q/NgUG9KvA9rWOjgwKATMTqv3mpcbcDgQxaLRbpYyp+89/5tLMF98GTAVZsP4LfpAuXRYnALBwof+0AxejR0EVVpO4ARbvpz96D1GV7FvNoJB4lNDLiQOKofIQSTicQcnzeq5ZUsxTpi8ctQJeVrJmNj8wbEWxHhYNxjXff8UiT1vww1Oq9R59Dgz1gGb5Kff5a62jA/4tD222Ml75J4zd+8uglmfcQB76s2nktsM2w2z8p2yamWG90eTNrd9ly/ALnAtlP8LO5a1FdSo9sv7h3cVvGqGHkXT9Sr+3ZcjO4faNNYUMErkHf2tIeuqBNhjc0bHXEDoVHBa20qeRm1liw1Mq9H29z68Ard+hs7f0BzWD/3S8g7q+TV3RohR8VVLqq34pgR2G8NL9O8alx3Rrvy7Cr3q2LkXTyPClrBY55JgPqCthFGVbxsgbxxRd2jxKCGTS/zpelW0beD8pB4NxVhVw7t2HSvj0m9lfUx5A/zzWw2q0yPHzYHjWEOuDXvWLnhAtL1Gah3XrWsImkL/WjAkoX7au+r00bQ7my+qFr4ekETpFvyUGsOKOAgZrNNZaE2InCx9XF/qVmFQwNGBVevs42n31K9+5oqFxw0GURc22UayXjBenHrY1Z7UJ/FpOCkRsFjWe+SNsLuef2xCm0QMfvwe60pxnGf5v7iNTR/xWZWb8GjWcOFgBtK3FLBM+uTCpatd5aigue1Pngs4yVcp8VphmT+YYuQGIhxm/Fu37w+j0mPBk4+BIy4ett8q52lGJTneJsbHwHGwx/FQYp2Q6wtogCWH8DNLtdt0S1Pi6RICx8JG1nFCluOV9yWLgrrjAI4HfVQNtYu5emw9ri0EyZGWpCNORYxvVuAGZeHgLIuEVZB5UnAqGLryfsLvDx31Gfa6czSSW+D7XRFVZgEyizlRfEm3yJFSaiM+HQ5Ee5ll3SNVgCczkvi+SJ5c+PMMtIV0BLu6RL32P8Lry8pcVHJcZoYlniDcCNJ49Xp+/uk5QK20PP0kLWYP8qsg2zuvl/VyAlQS1bQ7SnjfQ814O7WeF4jX/P/5l//fT2V77svePeNd/gFNam/FN/eZPd9io0B/ojOwMWVsA8/wO1RZvc/nOgTbqfi7okAfDbUe+KDjcVsPq9X81eJPK/g/So476kfWUG1S6vjmcIqYpGkGwT7r4t8FfffdIP7ajmdNlnC2Qto2fWNtixjudRr4a+VLF0uTa4vJF8XKuXbg/Hr33TjffKn3gp/kkkmmWSSSSaZZJJJJplkkkkmmWSS/yf5H6HANgUotAMHAAAAAElFTkSuQmCC
-    mediatype: image/png
+    - base64data: iVBORw0KGgoAAAANSUhEUgAAAK8AAACvCAMAAAC8TH5HAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAB1UExURQAAAJGS77CC4pCS75yM64uV8pSQ7puA85OV87OB4auF5Hyd+H2c936b9n6b94Ca9n+b9n+b9n+b9qOJ56SI55yM6qSI536b96aH5q2D45mN64OZ9ZWQ7oyU8XWg+6uG5oqg/p6L6m+k/ZuY+3mr/6qQ9LqM80D8C0oAAAAbdFJOUwA67R4KKxMBBP6ak6vZgVtJxG5ot+hQ7YDVkwC2C58AAAuSSURBVHja7ZyJerK8EoCDCSTKjoiIS13of/+XeGYm4NLKrvj1OYxt7aa8TiazJZGxSSaZZJJJJvmcSCn/Eq7Cz79DLJk0rb+kXdM9nz0m/4p2mZufz3lAZvEn1HsGye2J9128h7/Gezj8Nd7D3+I9/xu8SjWHrS76bfN8A+NsYxjowCvbPN+QSGB6kWi6QHteyQLPfx+wYsH2eHSthgu05lXMy/PceRcwxtnjdnts4mjLq5hBceVdcVsya71FMeov0JIXMuQwR+DoXX5EMgf0uz2GrDYbb8mrmE+4Z/NdvDCApN+jX3uFdrySqfW70wzFbFLwWtVNkXa8ONlIvfx9Dk0xSyvYq0NpxasYJ9o8emcUVCw6EjGvuUpLXgfVm9cP1fAZp1yyCKeGBf8pB96g9jUZ57c6s1vIIAUfjXqY9eFg1yiuKJnOECzeW+TJm0+rxRGGWfcP7/dld8bZwqcp/dJqIs9hrJIJ/JD2abV5j1StfJn1/pofo/Kx0ae1KfAO7/Vld7anfVpf28M5kKPDc9kYLRW4RDhIwYV/PozVUAF39Qre3BmrvsM04nisjHHyJlUjZEOefuBj8UIA81zHfGJ84BYeHAP9LKseP1r5LNnvOlHeXJgqRZbUPzT97PHvBVb48VCX09W54du2u3ZJwjD0It/gqmCue/yoolm4b7tQjmohh7cGAWzHC8x/qOFOZmBG4bbERDkQrVYyiGP7iPwPLGrgsAofYbePonEJ2CHxAuvjxEjLvfUj7J1BaP0irY3i888SA63l3alWgwKjbXueZztOSBoucOE33huIZdsWHChXRds72O069PyHhSEBDiOynbAEBiGreCGJKoa5zT8GVBzt4QNgXc+wbq4YvW+hSMkDYNa4EYihWqlYtmouSsYTo4XvgWezHKDcI+7xuPbMMp7JH0GEfhZGRMDIG5FRtLG1IGCNvTp/d9nFZhMx/DXYH/cgSBv6SscM+Tyf0P450Lw+iCmbOGAMonOeO/XlMyTjgAsfmWAN9Y53RFy0hDAovXBDSBFBVAIHDdUJ2lre3J6AVG9Hcln5NQyKCUcrd390g5/BtjpNR2KNGwTVpRDSmk6et6jwCv0ScVhpxopxl3DBIjzVjrYk5gVuEPAaw7UP+aFV+0ex5Aq8y/hTYhiE/UXjhibrlBUisUm8hmHwqujuH3IqQLA/0dT+Af8Q34hT8du3QXlR4nrdkxhJ0554nwAXhpvj+hLUo2u/zWoJM1aXy70ZP8e97APWJ+WGbN1AXNP8tedAasM96PLu4Ik2jhpHZLkqgdGM5TNjuKzNnhkiUmneH8CSCe9wpXV429HDlCu7GcV9JwemWoEbWr3rGZx2iMs5F4+T3S1p89DoYGvkUeLCKC67m+uBsVwVuGpI+QVohGtZ6rHrU+Cu/UaP/ps4KY3iWhlipwNwd4Arh1WLCIy4lpA/2yiF4XZ9ehgMuaRgt7r6FMWiC9DuL64YWtyCrQKuEOLe1iJsG+eO2W8eo+POdrvVtdULrgG0Dbg76xW1uCDcm5GCguzDAeNlz0qPqgfzGunJeAl4aOug6KYQ7l2WhI7DZEMqZ7L5a1uBZWTQF3/QVHvmUosOBX0ZVkbfkgNtDYCbDcDVsIKbQYCJBCY/gak7FHQh+bqiX7LwsnuYfr1gqUTCUsPWgsWdF1H2I1/ZoYBMSLs3o3/blyke+FRiEPE9c1Huq9dpV60GWQNmvybSIrCnee0SGIlDJzJfVzwrttTq7bfkUNCSzV71a19pScNOGHrmi9pWV/Uue6lXYpEcBFfgslSOPG0MBTASc/YK3455PEqvyYY5r0G4AeH6gWHqSCyVxQ2s9ksJw9B/ATBYVUy8fdRL6ZhhlPo1HpIyHelM38OmCuA6oWvzwTah69DTbiW6qxdMCdPdAIGLbrC8lyIimxHRgrhQcA+cdoqluxXc0u7qhcTGNBAYeKkB9CTASfJjVuTo7mvoRsO676Ci+LRanVbd91YgLggp2GI1/kpRq7MAXnuDjBhC8Qpkl3UepwIXgblseDQq2XBcUK8bru0hGgbni7ynzrMNs1xOuJDmNQMAsfAI2B0CjOaAvKuuK2aES8C8XU8Sn98H9SKw12/SwfwVzNyArOLOL1lxEpO37/lKFujlpW3UfTSZwpxaQCkXb+JVd3OAAg1xrQ4vFGzC0MDrbuvLSGtRiSVYuonjeNU5MxMWAVudZzct1azdLmUXzGZLV7BCySxG6Zrq4MsFXqv79A7WiLu1OwwLFgElr7VA3LQjLtZnCCx7+KNo7a4BuG3lhRmKWXQ0LME40Gbxsqt6BQH3arExZ+viCl67Ib1rGHFLQPIQL7JFnHTjRfUCb68whR1mXM3dttpjcWvIAS6uNCRxlmVxxypeCVJw3wjl0/LzmrfaVG4kBgFT6ge57wJ4M7OTfmlNS4j+McpB4G2rTfBGkhAwp2UcWfB2cw/FFogBKQvxrhtTLMnMZYJiFG4eeLM0zVLRg3dIzmJvAbfRgiXjS81rXfeBLIE3TTuVQneZeH8Fb4HXFQ0rcGKJcsNFXsRdduYdViSQBQNy0LCilaSIu+R3TeqP8KKLQAXXzjgw3hR5l3erFvoldOOVr9Cv5eK6v1tzXch0UZfLNGEPvGQi3fU7tMi1m45PgCtb4Nin974Lftmd9yUtJZ94q/NgUG9KvA9rWOjgwKATMTqv3mpcbcDgQxaLRbpYyp+89/5tLMF98GTAVZsP4LfpAuXRYnALBwof+0AxejR0EVVpO4ARbvpz96D1GV7FvNoJB4lNDLiQOKofIQSTicQcnzeq5ZUsxTpi8ctQJeVrJmNj8wbEWxHhYNxjXff8UiT1vww1Oq9R59Dgz1gGb5Kff5a62jA/4tD222Ml75J4zd+8uglmfcQB76s2nktsM2w2z8p2yamWG90eTNrd9ly/ALnAtlP8LO5a1FdSo9sv7h3cVvGqGHkXT9Sr+3ZcjO4faNNYUMErkHf2tIeuqBNhjc0bHXEDoVHBa20qeRm1liw1Mq9H29z68Ard+hs7f0BzWD/3S8g7q+TV3RohR8VVLqq34pgR2G8NL9O8alx3Rrvy7Cr3q2LkXTyPClrBY55JgPqCthFGVbxsgbxxRd2jxKCGTS/zpelW0beD8pB4NxVhVw7t2HSvj0m9lfUx5A/zzWw2q0yPHzYHjWEOuDXvWLnhAtL1Gah3XrWsImkL/WjAkoX7au+r00bQ7my+qFr4ekETpFvyUGsOKOAgZrNNZaE2InCx9XF/qVmFQwNGBVevs42n31K9+5oqFxw0GURc22UayXjBenHrY1Z7UJ/FpOCkRsFjWe+SNsLuef2xCm0QMfvwe60pxnGf5v7iNTR/xWZWb8GjWcOFgBtK3FLBM+uTCpatd5aigue1Pngs4yVcp8VphmT+YYuQGIhxm/Fu37w+j0mPBk4+BIy4ett8q52lGJTneJsbHwHGwx/FQYp2Q6wtogCWH8DNLtdt0S1Pi6RICx8JG1nFCluOV9yWLgrrjAI4HfVQNtYu5emw9ri0EyZGWpCNORYxvVuAGZeHgLIuEVZB5UnAqGLryfsLvDx31Gfa6czSSW+D7XRFVZgEyizlRfEm3yJFSaiM+HQ5Ee5ll3SNVgCczkvi+SJ5c+PMMtIV0BLu6RL32P8Lry8pcVHJcZoYlniDcCNJ49Xp+/uk5QK20PP0kLWYP8qsg2zuvl/VyAlQS1bQ7SnjfQ814O7WeF4jX/P/5l//fT2V77svePeNd/gFNam/FN/eZPd9io0B/ojOwMWVsA8/wO1RZvc/nOgTbqfi7okAfDbUe+KDjcVsPq9X81eJPK/g/So476kfWUG1S6vjmcIqYpGkGwT7r4t8FfffdIP7ajmdNlnC2Qto2fWNtixjudRr4a+VLF0uTa4vJF8XKuXbg/Hr33TjffKn3gp/kkkmmWSSSSaZZJJJJplkkkkmmWSS/yf5H6HANgUotAMHAAAAAElFTkSuQmCC
+      mediatype: image/png
   install:
     spec:
       deployments: null
     strategy: ""
   installModes:
-  - supported: true
-    type: OwnNamespace
-  - supported: true
-    type: SingleNamespace
-  - supported: true
-    type: MultiNamespace
-  - supported: false
-    type: AllNamespaces
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: false
+      type: AllNamespaces
   keywords:
-  - IBMLicensing
-  - IBM
-  - Cloud
-  - License
-  - Service
-  - License Service
+    - IBMLicensing
+    - IBM
+    - Cloud
+    - License
+    - Service
+    - License Service
   labels:
     name: ibm-licensing-operator
   links:
-  - name: GitHub
-    url: https://github.com/IBM/ibm-licensing-operator
+    - name: GitHub
+      url: https://github.com/IBM/ibm-licensing-operator
   maintainers:
-  - email: talk2sam@us.ibm.com
-    name: talk2sam
+    - email: talk2sam@us.ibm.com
+      name: talk2sam
   maturity: alpha
   provider:
     name: IBM
   relatedImages:
-  - image: icr.io/cpopen/ibm-licensing-operator:4.2.24
-    name: IBM_LICENSING_OPERATOR_IMAGE
-  - image: icr.io/cpopen/cpfs/ibm-licensing:4.2.24
-    name: IBM_LICENSING_IMAGE
+    - image: icr.io/cpopen/ibm-licensing-operator:4.2.24
+      name: IBM_LICENSING_OPERATOR_IMAGE
+    - image: icr.io/cpopen/cpfs/ibm-licensing:4.2.24
+      name: IBM_LICENSING_IMAGE
   version: 0.0.0

--- a/deploy/argo-cd/components/license-service/helm-cluster-scoped/templates/crd.yaml
+++ b/deploy/argo-cd/components/license-service/helm-cluster-scoped/templates/crd.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.1
     argocd.argoproj.io/sync-wave: "-1"
+    licensing.ibm.com/version: {{ .Chart.Version }}
   labels:
     app.kubernetes.io/instance: ibm-licensing-operator
     app.kubernetes.io/managed-by: ibm-licensing-operator
@@ -107,6 +108,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.1
     argocd.argoproj.io/sync-wave: "-1"
+    licensing.ibm.com/version: {{ .Chart.Version }}
   labels:
     app.kubernetes.io/instance: ibm-licensing-operator
     app.kubernetes.io/managed-by: ibm-licensing-operator
@@ -189,6 +191,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.1
     argocd.argoproj.io/sync-wave: "-1"
+    licensing.ibm.com/version: {{ .Chart.Version }}
   labels:
     app.kubernetes.io/instance: ibm-licensing-operator
     app.kubernetes.io/managed-by: ibm-licensing-operator
@@ -267,6 +270,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.1
     argocd.argoproj.io/sync-wave: "-1"
+    licensing.ibm.com/version: {{ .Chart.Version }}
   labels:
     app.kubernetes.io/instance: ibm-licensing-operator
     app.kubernetes.io/managed-by: ibm-licensing-operator


### PR DESCRIPTION
## Description
[to be merged for 4.19.3] Introduce custom metadata `annotation:licensing.ibm.com/version` which contains version number. To be able do identify the version of deployed CRDs

`licensing.ibm.com/version: 4.2.24`

## Parent issue
https://jsw.ibm.com/browse/ILS-2689

## Type
What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which modifies existing functionality)
- [ ] Dependency/version upgrade/CVE remediation
- [ ] Velocity-improvement (enhancing testing strategy, tidy code, CICD update)

## Extra information
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Lint and unit tests pass locally with my changes
- [x] Tester is needed
- [ ] This change requires a documentation update - create separate issue with input for *doc* team

## Testing
- [x] Manual tests
- [ ] Automated sert tests: <provide console log from succesful run here>
Before merging your PR, ensure Jenkins tests pass by following these steps:
1. Run the tests on the clustered environment (OCP/IKS depending on the content of the pull request) using Jenkins pipelines.
2. If the build fails due to being unstable, restart it.
3. If the failure is due to other issues unrelated to the tests themselves, address the underlying problem before proceeding.

## Test images for further QA testing (if applicable):
-
-
